### PR TITLE
Stop news-digest email template from breaking every morning

### DIFF
--- a/apps/news-digest/pipeline/project.json
+++ b/apps/news-digest/pipeline/project.json
@@ -17,6 +17,12 @@
     "test": {},
     "lint": {},
     "oxlint": {},
+    "preview-email": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx esbuild apps/news-digest/pipeline/src/distribution/preview.ts --bundle --platform=node --target=node22 --outfile=dist/apps/news-digest/pipeline/preview.mjs --format=esm --external:@aws-sdk/* && node dist/apps/news-digest/pipeline/preview.mjs"
+      }
+    },
     "docker-build": {
       "executor": "nx:run-commands",
       "inputs": ["{projectRoot}/src/**/*.ts", "^default"],

--- a/apps/news-digest/pipeline/src/distribution/__tests__/__snapshots__/email-template.helpers.spec.ts.snap
+++ b/apps/news-digest/pipeline/src/distribution/__tests__/__snapshots__/email-template.helpers.spec.ts.snap
@@ -1,0 +1,230 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildEmailHtml — snapshot > matches the canonical fixture snapshot 1`] = `
+"<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Industry News Digest - 2026-04-09</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; background-color: #F5F8FA; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; -webkit-font-smoothing: antialiased;">
+  <!-- Outer wrapper -->
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #F5F8FA;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <!-- Inner container -->
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="width: 600px;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background-color: #000D33; border-radius: 12px 12px 0 0; padding: 32px 32px 24px 32px; text-align: center;">
+              <!-- Logo -->
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding-bottom: 20px;">
+                    
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td style="font-size: 28px; font-weight: 700; color: #FFFFFF; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; letter-spacing: -0.5px;">
+          <span style="color: #007F82;">&#x1f955;</span>&nbsp;&nbsp;<span style="color: #EAEAEA;">carrot</span>
+        </td>
+      </tr>
+    </table>
+                  </td>
+                </tr>
+              </table>
+              <!-- Divider line -->
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding-bottom: 20px;">
+                    <div style="width: 60px; height: 3px; background-color: #F58216; border-radius: 2px; font-size: 0; line-height: 0;">&#8203;</div>
+                  </td>
+                </tr>
+              </table>
+              <!-- Title -->
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="font-size: 24px; font-weight: 700; color: #FFFFFF; letter-spacing: -0.3px; padding-bottom: 6px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">Industry News Digest</td>
+                </tr>
+                <tr>
+                  <td align="center" style="font-size: 14px; color: #94A3B8; line-height: 20px;">Thursday, April 9, 2026</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Stats bar -->
+          <tr>
+            <td style="background-color: #FFFFFF; padding: 16px 32px; border-bottom: 1px solid #E2E8F0;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="font-size: 13px; color: #768196;">
+                    <span style="font-weight: 700; color: #007F82; font-size: 18px;">2</span>
+                    <span style="margin-left: 4px;">articles extracted from</span>
+                    <span style="font-weight: 600; color: #000D33;">Carbon Pulse & ESG News</span>
+                  </td>
+                  <td align="right" style="font-size: 12px; color: #768196;">
+                    2 themes covered
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Articles -->
+          <tr>
+            <td style="background-color: #F5F8FA; padding: 24px 24px 8px 24px;">
+              
+    <!-- Article Card -->
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 16px;">
+      <tr>
+        <td style="background-color: #FFFFFF; border-radius: 8px; border: 1px solid #E2E8F0;">
+          <!-- Theme accent bar -->
+          <div style="height: 4px; background-color: #D97706; font-size: 0; line-height: 0; border-radius: 8px 8px 0 0;">&#8203;</div>
+          <!-- Card content -->
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+            <tr>
+              <td style="padding: 20px 24px;">
+                <!-- Theme badge -->
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td style="background-color: #FEF3C7; border-radius: 4px; padding: 3px 10px 3px 10px;">
+                      <span style="font-size: 11px; font-weight: 600; color: #D97706; text-transform: uppercase; letter-spacing: 0.5px;">Methane &amp; Super Pollutants</span>
+                    </td>
+                  </tr>
+                </table>
+                <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
+                <!-- Title -->
+                <a href="https://carbon-pulse.com/article/123/" style="text-decoration: none; color: #000D33;">
+                  <h2 style="margin: 0; font-size: 17px; font-weight: 700; line-height: 24px; color: #000D33;">EU launches methane monitoring framework</h2>
+                </a>
+                <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
+                <!-- Meta -->
+                <p style="margin: 0; font-size: 12px; color: #768196; line-height: 18px;">
+                  Alice Reporter &nbsp;&#183;&nbsp; Apr 8, 2026 &nbsp;&#183;&nbsp; <a href="https://carbon-pulse.com/article/123/" style="color: #007F82; text-decoration: none;">Carbon Pulse</a>
+                </p>
+                <div style="font-size: 0; line-height: 0; height: 12px;">&#8203;</div>
+                <!-- Summary -->
+                <p style="margin: 0; font-size: 14px; line-height: 22px; color: #4A5568;">The EU proposed a framework for monitoring &amp; reporting methane emissions across sectors.</p>
+                
+      <div style="font-size: 0; line-height: 0; height: 12px;">&#8203;</div>
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+        
+        <tr>
+          <td width="20" valign="top" style="padding: 2px 8px 4px 0; color: #F58216; font-size: 8px; line-height: 20px;">&#9679;</td>
+          <td style="padding: 2px 0 4px 0; font-size: 13px; line-height: 20px; color: #768196;">Policy proposal published</td>
+        </tr>
+        <tr>
+          <td width="20" valign="top" style="padding: 2px 8px 4px 0; color: #F58216; font-size: 8px; line-height: 20px;">&#9679;</td>
+          <td style="padding: 2px 0 4px 0; font-size: 13px; line-height: 20px; color: #768196;">Covers oil, gas, and coal sectors</td>
+        </tr>
+      </table>
+                <div style="font-size: 0; line-height: 0; height: 16px;">&#8203;</div>
+                <!-- Read more -->
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td style="background-color: #007F82; border-radius: 4px;">
+                      <a href="https://carbon-pulse.com/article/123/" style="display: inline-block; padding: 8px 20px; font-size: 13px; font-weight: 600; color: #FFFFFF; text-decoration: none;">Read full article</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+
+    <!-- Article Card -->
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 16px;">
+      <tr>
+        <td style="background-color: #FFFFFF; border-radius: 8px; border: 1px solid #E2E8F0;">
+          <!-- Theme accent bar -->
+          <div style="height: 4px; background-color: #059669; font-size: 0; line-height: 0; border-radius: 8px 8px 0 0;">&#8203;</div>
+          <!-- Card content -->
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+            <tr>
+              <td style="padding: 20px 24px;">
+                <!-- Theme badge -->
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td style="background-color: #D1FAE5; border-radius: 4px; padding: 3px 10px 3px 10px;">
+                      <span style="font-size: 11px; font-weight: 600; color: #059669; text-transform: uppercase; letter-spacing: 0.5px;">Circularity &amp; Composting</span>
+                    </td>
+                  </tr>
+                </table>
+                <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
+                <!-- Title -->
+                <a href="https://esgnews.com/article/456/" style="text-decoration: none; color: #000D33;">
+                  <h2 style="margin: 0; font-size: 17px; font-weight: 700; line-height: 24px; color: #000D33;">Major retailer announces composting program</h2>
+                </a>
+                <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
+                <!-- Meta -->
+                <p style="margin: 0; font-size: 12px; color: #768196; line-height: 18px;">
+                  Bob Writer &nbsp;&#183;&nbsp; Apr 9, 2026 &nbsp;&#183;&nbsp; <a href="https://esgnews.com/article/456/" style="color: #007F82; text-decoration: none;">ESG News</a>
+                </p>
+                <div style="font-size: 0; line-height: 0; height: 12px;">&#8203;</div>
+                <!-- Summary -->
+                <p style="margin: 0; font-size: 14px; line-height: 22px; color: #4A5568;">A major US retailer announced a nationwide composting program.</p>
+                
+      <div style="font-size: 0; line-height: 0; height: 12px;">&#8203;</div>
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+        
+        <tr>
+          <td width="20" valign="top" style="padding: 2px 8px 4px 0; color: #F58216; font-size: 8px; line-height: 20px;">&#9679;</td>
+          <td style="padding: 2px 0 4px 0; font-size: 13px; line-height: 20px; color: #768196;">Rollout across 500 stores</td>
+        </tr>
+        <tr>
+          <td width="20" valign="top" style="padding: 2px 8px 4px 0; color: #F58216; font-size: 8px; line-height: 20px;">&#9679;</td>
+          <td style="padding: 2px 0 4px 0; font-size: 13px; line-height: 20px; color: #768196;">Partnership with local farms</td>
+        </tr>
+      </table>
+                <div style="font-size: 0; line-height: 0; height: 16px;">&#8203;</div>
+                <!-- Read more -->
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td style="background-color: #007F82; border-radius: 4px;">
+                      <a href="https://esgnews.com/article/456/" style="display: inline-block; padding: 8px 20px; font-size: 13px; font-weight: 600; color: #FFFFFF; text-decoration: none;">Read full article</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background-color: #000D33; border-radius: 0 0 12px 12px; padding: 24px 32px; text-align: center;">
+              <p style="margin: 0; font-size: 12px; color: #64748B; line-height: 18px;">
+                This digest is curated by <span style="color: #F58216; font-weight: 600;">Carrot Intelligence</span> from Carbon Pulse & ESG News.
+              </p>
+              <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
+              <p style="margin: 0; font-size: 11px; color: #475569; line-height: 16px;">
+                Carrot Foundation &nbsp;&#183;&nbsp; <a href="https://carrot.eco" style="color: #007F82; text-decoration: none;">carrot.eco</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"
+`;

--- a/apps/news-digest/pipeline/src/distribution/__tests__/email-template.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/distribution/__tests__/email-template.helpers.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest';
+import { buildEmailHtml } from '../email-template.helpers.js';
+import type { ProcessedArticle } from '../../types.js';
+
+function stubProcessedArticle(overrides: Partial<ProcessedArticle> = {}): ProcessedArticle {
+  return {
+    source: 'carbon-pulse',
+    url: 'https://carbon-pulse.com/article/123/',
+    title: 'Test Article',
+    date: '2026-04-09',
+    author: 'Test Author',
+    mainTheme: 'Carbon Markets',
+    categories: '',
+    location: '',
+    summary: 'A test summary.',
+    keyPoints: ['Point 1', 'Point 2'],
+    segment: 'Policy & Regulation',
+    fullContent: 'Content.',
+    markdownFile: 'test.md',
+    notionPageId: null,
+    processedAt: '2026-04-09T10:00:00Z',
+    status: 'markdown-only',
+    ...overrides,
+  };
+}
+
+function manyArticles(count: number): ProcessedArticle[] {
+  return Array.from({ length: count }, (_, i) =>
+    stubProcessedArticle({
+      url: `https://carbon-pulse.com/article/${i}/`,
+      title: `Article ${i}`,
+      mainTheme: i % 2 === 0 ? 'Carbon Markets' : 'Methane & Super Pollutants',
+    }),
+  );
+}
+
+describe('buildEmailHtml — render branches', () => {
+  it('renders the normal card branch when articles.length <= COMPACT_THRESHOLD', () => {
+    const html = buildEmailHtml(manyArticles(3), '2026-04-09');
+    expect(html).toContain('<!-- Article Card -->');
+    expect(html).not.toContain('<!-- Theme Section:');
+  });
+
+  it('renders the compact theme branch when articles.length > COMPACT_THRESHOLD', () => {
+    const html = buildEmailHtml(manyArticles(12), '2026-04-09');
+    expect(html).toContain('<!-- Theme Section:');
+    expect(html).not.toContain('<!-- Article Card -->');
+  });
+});
+
+describe('buildEmailHtml — escaping', () => {
+  it('escapes ampersand theme names in the compact branch (regression for line 199)', () => {
+    const articles = manyArticles(12).map((a, i) =>
+      i === 0 ? { ...a, mainTheme: 'Methane & Super Pollutants' } : a,
+    );
+    const html = buildEmailHtml(articles, '2026-04-09');
+    expect(html).toContain('Methane &amp; Super Pollutants');
+  });
+
+  it('escapes ampersand theme names in the normal card branch', () => {
+    const html = buildEmailHtml(
+      [stubProcessedArticle({ mainTheme: 'Methane & Super Pollutants' })],
+      '2026-04-09',
+    );
+    expect(html).toContain('Methane &amp; Super Pollutants');
+  });
+
+  it('escapes adversarial title / author / summary / key points', () => {
+    const html = buildEmailHtml(
+      [
+        stubProcessedArticle({
+          title: '<script>alert(1)</script>',
+          author: '"); drop',
+          summary: 'Bad <img onerror="x"> & stuff',
+          keyPoints: ['<b>bold</b>', 'a & b'],
+        }),
+      ],
+      '2026-04-09',
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).not.toContain('<img onerror="x">');
+    expect(html).not.toContain('<b>bold</b>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).toContain('&quot;); drop');
+    expect(html).toContain('Bad &lt;img onerror=&quot;x&quot;&gt; &amp; stuff');
+    expect(html).toContain('&lt;b&gt;bold&lt;/b&gt;');
+    expect(html).toContain('a &amp; b');
+  });
+
+  it('attribute-escapes URLs containing ampersands and quotes', () => {
+    const url = 'https://carbon-pulse.com/?a=1&b=%222%22';
+    const html = buildEmailHtml([stubProcessedArticle({ url })], '2026-04-09');
+    expect(html).toContain('&amp;');
+    // Raw unescaped `&b=` would appear if the href were not escaped.
+    expect(html).not.toContain('?a=1&b=');
+  });
+
+  it('rewrites javascript: URLs to href="#"', () => {
+    const html = buildEmailHtml(
+      [stubProcessedArticle({ url: 'javascript:alert(1)' })],
+      '2026-04-09',
+    );
+    expect(html).not.toContain('javascript:alert(1)');
+    expect(html).toContain('href="#"');
+  });
+
+  it('rewrites unparseable URLs to href="#"', () => {
+    const html = buildEmailHtml(
+      [stubProcessedArticle({ url: 'not-a-url' })],
+      '2026-04-09',
+    );
+    expect(html).toContain('href="#"');
+  });
+});
+
+describe('buildEmailHtml — date rendering', () => {
+  it('formats ISO dates as "Mon D, YYYY"', () => {
+    const html = buildEmailHtml(
+      [stubProcessedArticle({ date: '2026-04-09' })],
+      '2026-04-09',
+    );
+    expect(html).toContain('Apr 9, 2026');
+  });
+
+  it('falls back to escaped raw text for unparseable dates and does not throw', () => {
+    expect(() =>
+      buildEmailHtml(
+        [stubProcessedArticle({ date: 'sometime <last> week' })],
+        '2026-04-09',
+      ),
+    ).not.toThrow();
+    const html = buildEmailHtml(
+      [stubProcessedArticle({ date: 'sometime <last> week' })],
+      '2026-04-09',
+    );
+    expect(html).toContain('sometime &lt;last&gt; week');
+    expect(html).not.toContain('sometime <last> week');
+  });
+});
+
+describe('buildEmailHtml — minimal / empty', () => {
+  it('renders with no key points, no author, and no notionPageId', () => {
+    expect(() =>
+      buildEmailHtml(
+        [stubProcessedArticle({ keyPoints: [], author: '', notionPageId: null })],
+        '2026-04-09',
+      ),
+    ).not.toThrow();
+  });
+
+  it('does not emit a keypoint table when keyPoints is empty', () => {
+    const html = buildEmailHtml(
+      [stubProcessedArticle({ keyPoints: [] })],
+      '2026-04-09',
+    );
+    // The keypoint table uses a leading 12px div spacer in the markup.
+    // When there are no keypoints, the whole block is omitted.
+    const bulletMarker = '&#9679;';
+    expect(html).not.toContain(bulletMarker);
+  });
+});
+
+describe('buildEmailHtml — Gmail CSS regression guards', () => {
+  // These guards exist because each of the last four mornings reintroduced
+  // one of these patterns in a different part of the template. If any of
+  // them fires, re-run step 2/3 of the plan and finish the sweep before
+  // shipping.
+  const scenarios: Array<[string, number]> = [
+    ['normal branch (3 articles)', 3],
+    ['compact branch (12 articles)', 12],
+  ];
+
+  for (const [label, count] of scenarios) {
+    it(`${label}: no "background: #..." shorthand`, () => {
+      const html = buildEmailHtml(manyArticles(count), '2026-04-09');
+      expect(html).not.toMatch(/background:\s*#/);
+    });
+
+    it(`${label}: no "font-size: 1px" (dark-mode border bug)`, () => {
+      const html = buildEmailHtml(manyArticles(count), '2026-04-09');
+      expect(html).not.toContain('font-size: 1px');
+    });
+
+    it(`${label}: no non-zero margin on p/h elements`, () => {
+      const html = buildEmailHtml(manyArticles(count), '2026-04-09');
+      // Zero margins are fine; any non-zero px margin should be gone.
+      expect(html).not.toMatch(/margin:\s*\d*[1-9]\d*\s*px/);
+      expect(html).not.toMatch(/margin:\s*0\s+0\s+[1-9]/);
+    });
+  }
+});
+
+describe('buildEmailHtml — snapshot', () => {
+  it('matches the canonical fixture snapshot', () => {
+    const fixture: ProcessedArticle[] = [
+      stubProcessedArticle({
+        title: 'EU launches methane monitoring framework',
+        author: 'Alice Reporter',
+        mainTheme: 'Methane & Super Pollutants',
+        date: '2026-04-08',
+        summary: 'The EU proposed a framework for monitoring & reporting methane emissions across sectors.',
+        keyPoints: ['Policy proposal published', 'Covers oil, gas, and coal sectors'],
+      }),
+      stubProcessedArticle({
+        url: 'https://esgnews.com/article/456/',
+        source: 'esgnews',
+        title: 'Major retailer announces composting program',
+        author: 'Bob Writer',
+        mainTheme: 'Circularity & Composting',
+        date: '2026-04-09',
+        summary: 'A major US retailer announced a nationwide composting program.',
+        keyPoints: ['Rollout across 500 stores', 'Partnership with local farms'],
+      }),
+    ];
+    const html = buildEmailHtml(fixture, '2026-04-09');
+    expect(html).toMatchSnapshot();
+  });
+});

--- a/apps/news-digest/pipeline/src/distribution/email-template.helpers.ts
+++ b/apps/news-digest/pipeline/src/distribution/email-template.helpers.ts
@@ -9,6 +9,29 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#039;');
 }
 
+function safeHref(value: string): string {
+  try {
+    const u = new URL(value);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:' && u.protocol !== 'mailto:') {
+      return '#';
+    }
+    return escapeHtml(u.toString());
+  } catch {
+    return '#';
+  }
+}
+
+function formatArticleDate(raw: string): string {
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return escapeHtml(raw);
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
 const MAX_SUMMARY_LENGTH = 500;
 const COMPACT_THRESHOLD = 10;
 
@@ -129,13 +152,15 @@ function buildArticleCard(article: ProcessedArticle): string {
                 </table>
                 <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
                 <!-- Title -->
-                <a href="${url}" style="text-decoration: none; color: ${BRAND.darkNavy};">
-                  <h2 style="margin: 0 0 8px 0; font-size: 17px; font-weight: 700; line-height: 24px; color: ${BRAND.darkNavy};">${escapeHtml(article.title)}</h2>
+                <a href="${safeHref(url)}" style="text-decoration: none; color: ${BRAND.darkNavy};">
+                  <h2 style="margin: 0; font-size: 17px; font-weight: 700; line-height: 24px; color: ${BRAND.darkNavy};">${escapeHtml(article.title)}</h2>
                 </a>
+                <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
                 <!-- Meta -->
-                <p style="margin: 0 0 12px 0; font-size: 12px; color: ${BRAND.mutedText}; line-height: 18px;">
-                  ${escapeHtml(article.author)} &nbsp;&#183;&nbsp; ${article.date} &nbsp;&#183;&nbsp; <a href="${article.url}" style="color: ${BRAND.teal}; text-decoration: none;">${sourceName}</a>
+                <p style="margin: 0; font-size: 12px; color: ${BRAND.mutedText}; line-height: 18px;">
+                  ${escapeHtml(article.author)} &nbsp;&#183;&nbsp; ${formatArticleDate(article.date)} &nbsp;&#183;&nbsp; <a href="${safeHref(article.url)}" style="color: ${BRAND.teal}; text-decoration: none;">${sourceName}</a>
                 </p>
+                <div style="font-size: 0; line-height: 0; height: 12px;">&#8203;</div>
                 <!-- Summary -->
                 <p style="margin: 0; font-size: 14px; line-height: 22px; color: #4A5568;">${escapeHtml(summary)}</p>
                 ${keyPointsHtml}
@@ -144,7 +169,7 @@ function buildArticleCard(article: ProcessedArticle): string {
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0">
                   <tr>
                     <td style="background-color: ${BRAND.teal}; border-radius: 4px;">
-                      <a href="${url}" style="display: inline-block; padding: 8px 20px; font-size: 13px; font-weight: 600; color: ${BRAND.white}; text-decoration: none;">Read full article</a>
+                      <a href="${safeHref(url)}" style="display: inline-block; padding: 8px 20px; font-size: 13px; font-weight: 600; color: ${BRAND.white}; text-decoration: none;">Read full article</a>
                     </td>
                   </tr>
                 </table>
@@ -166,11 +191,14 @@ function buildCompactArticleRow(article: ProcessedArticle): string {
       <td style="padding: 12px 16px; border-bottom: 1px solid ${BRAND.border};">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
           <tr>
-            <td width="4" style="background: ${color}; border-radius: 2px; font-size: 1px;">&nbsp;</td>
+            <td width="4" valign="top">
+              <div style="width: 4px; height: 40px; background-color: ${color}; border-radius: 2px; font-size: 0; line-height: 0;">&#8203;</div>
+            </td>
             <td style="padding-left: 12px;">
-              <a href="${url}" style="text-decoration: none; color: ${BRAND.darkNavy}; font-size: 14px; font-weight: 600; line-height: 20px;">${escapeHtml(article.title)}</a>
-              <p style="margin: 4px 0 0 0; font-size: 12px; color: ${BRAND.mutedText}; line-height: 16px;">
-                ${escapeHtml(article.author)} &nbsp;&#183;&nbsp; ${article.date} &nbsp;&#183;&nbsp; <span style="color: ${BRAND.teal};">${srcLabel}</span>
+              <a href="${safeHref(url)}" style="text-decoration: none; color: ${BRAND.darkNavy}; font-size: 14px; font-weight: 600; line-height: 20px;">${escapeHtml(article.title)}</a>
+              <div style="font-size: 0; line-height: 0; height: 4px;">&#8203;</div>
+              <p style="margin: 0; font-size: 12px; color: ${BRAND.mutedText}; line-height: 16px;">
+                ${escapeHtml(article.author)} &nbsp;&#183;&nbsp; ${formatArticleDate(article.date)} &nbsp;&#183;&nbsp; <span style="color: ${BRAND.teal};">${srcLabel}</span>
               </p>
             </td>
           </tr>
@@ -184,7 +212,7 @@ function buildCompactThemeSection(theme: string, articles: readonly ProcessedArt
   const rows = articles.map(buildCompactArticleRow).join('\n');
 
   return `
-    <!-- Theme Section: ${theme} -->
+    <!-- Theme Section: ${escapeHtml(theme)} -->
     <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 16px;">
       <tr>
         <td style="background-color: ${BRAND.cardBg}; border-radius: 8px; border: 1px solid ${BRAND.border};">
@@ -196,7 +224,7 @@ function buildCompactThemeSection(theme: string, articles: readonly ProcessedArt
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0">
                   <tr>
                     <td style="background-color: ${themeBgColor(theme)}; border-radius: 4px; padding: 3px 10px;">
-                      <span style="font-size: 11px; font-weight: 600; color: ${color}; text-transform: uppercase; letter-spacing: 0.5px;">${theme}</span>
+                      <span style="font-size: 11px; font-weight: 600; color: ${color}; text-transform: uppercase; letter-spacing: 0.5px;">${escapeHtml(theme)}</span>
                     </td>
                     <td style="padding-left: 8px; font-size: 11px; color: ${BRAND.mutedText};">${articles.length} article${articles.length !== 1 ? 's' : ''}</td>
                   </tr>
@@ -291,7 +319,7 @@ export function buildEmailHtml(articles: readonly ProcessedArticle[], today: str
 
           <!-- Stats bar -->
           <tr>
-            <td style="background: ${BRAND.white}; padding: 16px 32px; border-bottom: 1px solid ${BRAND.border};">
+            <td style="background-color: ${BRAND.white}; padding: 16px 32px; border-bottom: 1px solid ${BRAND.border};">
               <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
                 <tr>
                   <td style="font-size: 13px; color: ${BRAND.mutedText};">
@@ -309,17 +337,18 @@ export function buildEmailHtml(articles: readonly ProcessedArticle[], today: str
 
           <!-- Articles -->
           <tr>
-            <td style="background: ${BRAND.lightBg}; padding: 24px 24px 8px 24px;">
+            <td style="background-color: ${BRAND.lightBg}; padding: 24px 24px 8px 24px;">
               ${articleCards}
             </td>
           </tr>
 
           <!-- Footer -->
           <tr>
-            <td style="background: ${BRAND.darkNavy}; border-radius: 0 0 12px 12px; padding: 24px 32px; text-align: center;">
-              <p style="margin: 0 0 8px 0; font-size: 12px; color: #64748B; line-height: 18px;">
+            <td style="background-color: ${BRAND.darkNavy}; border-radius: 0 0 12px 12px; padding: 24px 32px; text-align: center;">
+              <p style="margin: 0; font-size: 12px; color: #64748B; line-height: 18px;">
                 This digest is curated by <span style="color: ${BRAND.orange}; font-weight: 600;">Carrot Intelligence</span> from ${sourceNames}.
               </p>
+              <div style="font-size: 0; line-height: 0; height: 8px;">&#8203;</div>
               <p style="margin: 0; font-size: 11px; color: #475569; line-height: 16px;">
                 Carrot Foundation &nbsp;&#183;&nbsp; <a href="https://carrot.eco" style="color: ${BRAND.teal}; text-decoration: none;">carrot.eco</a>
               </p>

--- a/apps/news-digest/pipeline/src/distribution/preview.ts
+++ b/apps/news-digest/pipeline/src/distribution/preview.ts
@@ -1,0 +1,94 @@
+/**
+ * Local preview CLI for the news-digest email template.
+ *
+ * Run with: `pnpm nx run news-digest-pipeline:preview-email`
+ *
+ * Writes a rendered HTML file to `dist/news-digest-preview/digest.html`
+ * that can be opened in a browser or dragged into a Gmail compose window
+ * to sanity-check layout (light + dark, desktop + mobile) before deploy.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { buildEmailHtml } from './email-template.helpers.js';
+import type { ProcessedArticle } from '../types.js';
+
+function article(overrides: Partial<ProcessedArticle>): ProcessedArticle {
+  return {
+    source: 'carbon-pulse',
+    url: 'https://carbon-pulse.com/article/preview/',
+    title: 'Preview article',
+    date: '2026-04-09',
+    author: 'Preview Author',
+    mainTheme: 'Carbon Markets',
+    categories: '',
+    location: '',
+    summary: 'A preview summary that explains what the article covers in a concise way.',
+    keyPoints: ['First key point', 'Second key point', 'Third key point'],
+    segment: 'Policy & Regulation',
+    fullContent: '',
+    markdownFile: 'preview.md',
+    notionPageId: null,
+    processedAt: '2026-04-09T10:00:00Z',
+    status: 'markdown-only',
+    ...overrides,
+  };
+}
+
+// Fixture deliberately exercises the edge cases that have broken real
+// renders in the past: ampersand theme names, adversarial strings,
+// missing author, and non-ISO dates.
+const FIXTURE: ProcessedArticle[] = [
+  article({
+    title: 'EU launches methane monitoring framework',
+    mainTheme: 'Methane & Super Pollutants',
+    date: '2026-04-08',
+    summary:
+      'The EU proposed a framework for monitoring & reporting methane emissions across oil, gas, and coal sectors. The proposal includes binding targets and penalties for non-compliance.',
+    keyPoints: [
+      'Binding sector-specific targets',
+      'Penalties for non-compliance',
+      'Covers oil, gas, and coal',
+    ],
+  }),
+  article({
+    url: 'https://esgnews.com/article/456/',
+    source: 'esgnews',
+    title: 'Major retailer announces composting program',
+    author: 'Bob Writer',
+    mainTheme: 'Circularity & Composting',
+    date: '2026-04-09',
+    summary: 'A major US retailer announced a nationwide composting program.',
+    keyPoints: ['Rollout across 500 stores', 'Partnership with local farms'],
+  }),
+  article({
+    title: 'Adversarial input: <script>alert(1)</script> & "quoted"',
+    author: '',
+    mainTheme: 'Carbon Markets',
+    date: '2026-04-07',
+    summary: 'Tests that the template escapes < > & " \' correctly.',
+    keyPoints: ['<b>should not be bold</b>', 'a & b & c'],
+    notionPageId: null,
+  }),
+];
+
+const COMPACT_FIXTURE: ProcessedArticle[] = Array.from({ length: 12 }, (_, i) =>
+  article({
+    url: `https://carbon-pulse.com/article/compact-${i}/`,
+    title: `Compact branch article ${i + 1}`,
+    mainTheme: i % 3 === 0 ? 'Methane & Super Pollutants' : i % 3 === 1 ? 'Carbon Markets' : 'Circularity & Composting',
+    date: '2026-04-09',
+    keyPoints: [],
+  }),
+);
+
+function write(name: string, html: string): void {
+  const outDir = 'dist/news-digest-preview';
+  mkdirSync(outDir, { recursive: true });
+  const path = `${outDir}/${name}`;
+  writeFileSync(path, html);
+  console.log(`Wrote ${path}`);
+}
+
+const today = new Date().toISOString().slice(0, 10);
+write('digest-normal.html', buildEmailHtml(FIXTURE, today));
+write('digest-compact.html', buildEmailHtml(COMPACT_FIXTURE, today));
+console.log('\nOpen the files in a browser, or drag them into a Gmail compose window to preview.');

--- a/apps/news-digest/pipeline/src/scraper/__tests__/carbon-pulse.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/carbon-pulse.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { parseHumanDate } from '../carbon-pulse.js';
+
+describe('parseHumanDate', () => {
+  it.each<[string, string]>([
+    ['2026-04-09', '2026-04-09'],
+    ['April 9, 2026', '2026-04-09'],
+    ['9 April 2026', '2026-04-09'],
+    ['Apr 9, 2026', '2026-04-09'],
+  ])('normalizes %s to ISO', (input, expected) => {
+    expect(parseHumanDate(input)).toBe(expected);
+  });
+
+  it.each<[string]>([[''], ['garbage'], ['not-a-date']])(
+    'returns empty string for unparseable input %s',
+    (input) => {
+      expect(parseHumanDate(input)).toBe('');
+    },
+  );
+});

--- a/apps/news-digest/pipeline/src/scraper/carbon-pulse.ts
+++ b/apps/news-digest/pipeline/src/scraper/carbon-pulse.ts
@@ -47,7 +47,7 @@ async function login(page: Page, username: string, password: string): Promise<bo
   }
 }
 
-function parseHumanDate(raw: string): string {
+export function parseHumanDate(raw: string): string {
   const parsed = new Date(raw);
   if (!Number.isNaN(parsed.getTime())) {
     return parsed.toISOString().slice(0, 10);


### PR DESCRIPTION
### Summary

Stops the daily news-digest email template breakage by finishing the escape + Gmail-CSS sweeps that prior fixes (6ec2da6, c91da45, 1db7ccb) left incomplete, and adds regression tests plus a local preview CLI so future template tweaks can be verified before deploy instead of in production.

### Details

**Why the template kept breaking every morning.** The four prior fixes each addressed one real bug but missed the same pattern in other parts of the template. The render also branches on article count (`COMPACT_THRESHOLD = 10` in `apps/news-digest/pipeline/src/distribution/email-template.helpers.ts`), so a fix to one branch didn't protect the other. That's why re-runs "worked" — the re-run hit the cached-articles path in the orchestrator and re-rendered through whichever branch already had its gap patched — while the next morning broke again on different data or a different article count.

**1. Finish the escape sweep** (`apps/news-digest/pipeline/src/distribution/email-template.helpers.ts`)

Added `safeHref` and `formatArticleDate` helpers and patched 8 unescaped interpolations that could break the render with a single weird article:

- `article.date` in both the normal-card and compact-row meta rows
- `article.url` interpolated raw inside `href="..."`
- `url` from `articleUrl()` in the title anchor, "Read full article" button, and compact row title anchor
- `theme` in the compact theme badge and HTML comment (the normal-card branch already escaped it — the asymmetry was the specific bug)

`safeHref` also collapses non-`http(s)`/`mailto:` URLs to `href="#"` so a bad scrape can't inject a `javascript:` link.

**2. Finish the Gmail CSS sweep** (same file)

- Remaining `background:` shorthands on wrapper `<td>`s (stats bar, articles wrapper, footer) switched to `background-color:` — matches the intent of c91da45.
- Compact-row accent bar replaced the `font-size:1px &nbsp;` `<td>` pattern with the `div`-spacer pattern 1db7ccb standardized elsewhere — no more visible bordered boxes in Gmail dark mode.
- Non-zero `margin:` on `<p>`/`<h2>` replaced with `div` spacers so Gmail can't strip them.

**3. Add regression tests** (`apps/news-digest/pipeline/src/distribution/__tests__/email-template.helpers.spec.ts`)

- Branch coverage: normal-card (3 articles) and compact (12 articles) both render.
- Adversarial escaping: `<script>`, `"`, `'`, `&`, `<img onerror>` in title/author/summary/keypoints; `javascript:`/malformed URLs collapsed to `href="#"`; URLs with `&`/`"` attribute-escaped.
- Ampersand themes escape in both branches (regression for `Methane & Super Pollutants`).
- Date rendering: ISO dates format to `Apr 9, 2026`; unparseable dates fall back to escaped raw text and don't throw.
- **CSS regression guards** per branch: assert the rendered HTML never contains `background: #`, `font-size: 1px`, or non-zero `margin:` on `<p>`/`<h2>`. These three classes recurred in each morning's breakage — the guards make sure a future edit can't reintroduce them without a test failure.
- Snapshot of a canonical fixture to make template diffs visible in review.

**4. Add local preview CLI** (`apps/news-digest/pipeline/src/distribution/preview.ts` + `project.json`)

New `preview-email` Nx target that bundles `preview.ts` with esbuild and writes `dist/news-digest-preview/digest-normal.html` and `dist/news-digest-preview/digest-compact.html` from a fixture that deliberately exercises both branches, ampersand themes, adversarial strings, and a missing author. Closes the iteration loop: `pnpm nx run news-digest-pipeline:preview-email`, open in Chrome, then drag into Gmail compose to preview in the real client — no ECS deploy needed.

**5. `parseHumanDate` unit tests** (`apps/news-digest/pipeline/src/scraper/carbon-pulse.ts` + new `__tests__/carbon-pulse.spec.ts`)

Exported `parseHumanDate` and added a small table-driven test suite covering ISO passthrough, common human formats, and unparseable inputs. No Playwright dependency.

### How to verify

​`bash
pnpm install
pnpm nx build news-digest-pipeline
cd apps/news-digest/pipeline && pnpm exec vitest run   # 58/58 passing, 1 snapshot
pnpm nx run news-digest-pipeline:preview-email         # writes dist/news-digest-preview/*.html
​`

Open `dist/news-digest-preview/digest-normal.html` and `digest-compact.html` in a browser, then drag each into a Gmail compose window to eyeball the render in light mode, dark mode, and the mobile app.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes HTML generation logic (escaping, URL rewriting, date formatting) that affects all outgoing digest emails and could subtly alter rendering across clients, though it is well-covered by new unit/snapshot/CSS-guard tests.
> 
> **Overview**
> Stabilizes the news-digest email HTML output by **hardening escaping and link/date handling** in `buildEmailHtml`: adds `safeHref` to attribute-escape URLs and block non-`http(s)`/`mailto:` schemes, escapes compact-theme labels/comments, and formats article dates with a safe fallback for unparseable inputs.
> 
> Fixes Gmail-specific rendering regressions by removing `background:` shorthands, eliminating `font-size: 1px` spacer patterns, and replacing non-zero heading/paragraph margins with explicit spacers.
> 
> Adds comprehensive Vitest coverage (branch/escaping/date/CSS guards + snapshot), exports and tests `parseHumanDate`, and introduces an Nx `preview-email` target plus a small CLI to render local HTML previews for both normal and compact layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e36ed87e7392be1d96d1fdc20454efd868307c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->