### PR TITLE
Add Trellis as third data source in news-digest pipeline

### DIFF
--- a/apps/news-digest/pipeline/src/ai/__tests__/trellis-curator.spec.ts
+++ b/apps/news-digest/pipeline/src/ai/__tests__/trellis-curator.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { curateTrellisArticles, type TrellisCandidate } from '../trellis-curator.js';
+
+const THEME_NAMES = ['Methane & Super Pollutants', 'Circularity & Composting', 'Carbon Markets'];
+
+function stubCandidate(overrides: Partial<TrellisCandidate> = {}): TrellisCandidate {
+  return {
+    url: 'https://trellis.net/article/default/',
+    title: 'Default Title',
+    date: '2026-04-10',
+    excerpt: 'Default excerpt content for testing.',
+    ...overrides,
+  };
+}
+
+function anthropicResponse(picks: Array<{ url: string; mainTheme: string; reason: string }>): Response {
+  const body = JSON.stringify({
+    content: [{ type: 'text', text: JSON.stringify({ picks }) }],
+  });
+  return new Response(body, { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function anthropicText(rawText: string): Response {
+  const body = JSON.stringify({
+    content: [{ type: 'text', text: rawText }],
+  });
+  return new Response(body, { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+describe('curateTrellisArticles', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty array without calling the API when candidates are empty', async () => {
+    const result = await curateTrellisArticles([], THEME_NAMES, 'test-key');
+    expect(result).toEqual([]);
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('returns valid picks when Claude returns well-formed JSON', async () => {
+    const candidates = [
+      stubCandidate({ url: 'https://trellis.net/article/a/', title: 'A' }),
+      stubCandidate({ url: 'https://trellis.net/article/b/', title: 'B' }),
+    ];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicResponse([
+        { url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets', reason: 'ok' },
+        { url: 'https://trellis.net/article/b/', mainTheme: 'Methane & Super Pollutants', reason: 'ok' },
+      ]),
+    );
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([
+      { url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets' },
+      { url: 'https://trellis.net/article/b/', mainTheme: 'Methane & Super Pollutants' },
+    ]);
+  });
+
+  it('filters out picks whose URL is not in the candidate pool', async () => {
+    const candidates = [stubCandidate({ url: 'https://trellis.net/article/a/' })];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicResponse([
+        { url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets', reason: 'ok' },
+        { url: 'https://evil.example/', mainTheme: 'Carbon Markets', reason: 'bad' },
+      ]),
+    );
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([{ url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets' }]);
+  });
+
+  it('filters out picks whose mainTheme is not in themeNames', async () => {
+    const candidates = [stubCandidate({ url: 'https://trellis.net/article/a/' })];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicResponse([
+        { url: 'https://trellis.net/article/a/', mainTheme: 'Bogus Theme', reason: 'x' },
+      ]),
+    );
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([]);
+  });
+
+  it('caps picks at MAX_PICKS (2)', async () => {
+    const candidates = [
+      stubCandidate({ url: 'https://trellis.net/article/a/' }),
+      stubCandidate({ url: 'https://trellis.net/article/b/' }),
+      stubCandidate({ url: 'https://trellis.net/article/c/' }),
+    ];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicResponse([
+        { url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets', reason: '1' },
+        { url: 'https://trellis.net/article/b/', mainTheme: 'Carbon Markets', reason: '2' },
+        { url: 'https://trellis.net/article/c/', mainTheme: 'Carbon Markets', reason: '3' },
+      ]),
+    );
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when Claude returns non-JSON text', async () => {
+    const candidates = [stubCandidate()];
+    vi.mocked(fetch).mockResolvedValueOnce(anthropicText('not json at all'));
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when Claude returns JSON missing the picks field', async () => {
+    const candidates = [stubCandidate()];
+    vi.mocked(fetch).mockResolvedValueOnce(anthropicText(JSON.stringify({ other: 'field' })));
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when fetch rejects', async () => {
+    const candidates = [stubCandidate()];
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('network down'));
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when fetch returns non-2xx status', async () => {
+    const candidates = [stubCandidate()];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('error', { status: 500 }),
+    );
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([]);
+  });
+
+  it('tolerates markdown fences around JSON in Claude output', async () => {
+    const candidates = [stubCandidate({ url: 'https://trellis.net/article/a/' })];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicText('```json\n{"picks":[{"url":"https://trellis.net/article/a/","mainTheme":"Carbon Markets","reason":"ok"}]}\n```'),
+    );
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([{ url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets' }]);
+  });
+});

--- a/apps/news-digest/pipeline/src/ai/__tests__/trellis-curator.spec.ts
+++ b/apps/news-digest/pipeline/src/ai/__tests__/trellis-curator.spec.ts
@@ -131,6 +131,27 @@ describe('curateTrellisArticles', () => {
     expect(result).toEqual([]);
   });
 
+  it('returns empty array when fetch is aborted (timeout)', async () => {
+    const candidates = [stubCandidate()];
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    vi.mocked(fetch).mockRejectedValueOnce(abortError);
+    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    expect(result).toEqual([]);
+  });
+
+  it('passes an AbortSignal to fetch so the request can be timed out', async () => {
+    const candidates = [stubCandidate({ url: 'https://trellis.net/article/a/' })];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicResponse([
+        { url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets', reason: 'ok' },
+      ]),
+    );
+    await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const [, init] = vi.mocked(fetch).mock.calls[0]!;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('tolerates markdown fences around JSON in Claude output', async () => {
     const candidates = [stubCandidate({ url: 'https://trellis.net/article/a/' })];
     vi.mocked(fetch).mockResolvedValueOnce(

--- a/apps/news-digest/pipeline/src/ai/trellis-curator.ts
+++ b/apps/news-digest/pipeline/src/ai/trellis-curator.ts
@@ -1,0 +1,173 @@
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+const MODEL = 'claude-haiku-4-5-20251001';
+const MAX_TOKENS = 512;
+const MAX_PICKS = 2;
+
+export interface TrellisCandidate {
+  readonly url: string;
+  readonly title: string;
+  readonly date: string;
+  readonly excerpt: string;
+}
+
+export interface CuratedPick {
+  readonly url: string;
+  readonly mainTheme: string;
+}
+
+interface PickWithReason {
+  readonly url: string;
+  readonly mainTheme: string;
+  readonly reason: string;
+}
+
+const SYSTEM_PROMPT =
+  'You curate a daily sustainability and climate newsletter for the Carrot Foundation, ' +
+  'a Web3 impact platform focused on decarbonization, methane reduction, circular economy, ' +
+  'and tokenized environmental credits. Pick the 2 articles most valuable to a decarbonization ' +
+  'and circularity audience. Prefer original reporting over opinion pieces. Prefer more recent ' +
+  'articles when relevance is similar. Avoid picking two articles that cover the same story.';
+
+function buildUserPrompt(candidates: readonly TrellisCandidate[], themeNames: readonly string[]): string {
+  const payload = {
+    candidates: candidates.map((c) => ({
+      url: c.url, title: c.title, date: c.date, excerpt: c.excerpt,
+    })),
+    allowedThemes: themeNames,
+  };
+  return `${JSON.stringify(payload, null, 2)}
+
+Return ONLY JSON with this shape, no markdown, no commentary:
+{ "picks": [{ "url": "...", "mainTheme": "...", "reason": "..." }] }
+
+- "url" must exactly match one of the candidate URLs.
+- "mainTheme" must exactly match one of the allowed theme names.
+- "reason" is a short rationale (<= 200 chars).
+- Return at most 2 picks.`;
+}
+
+function parseClaudeText(rawText: string): unknown {
+  const stripped = rawText.replace(/^```(?:json)?\s*/m, '').replace(/```\s*$/m, '').trim();
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    return null;
+  }
+}
+
+function validatePicks(
+  raw: unknown,
+  candidateUrls: ReadonlySet<string>,
+  themeNames: ReadonlySet<string>,
+): readonly CuratedPick[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const picks = (raw as Record<string, unknown>)['picks'];
+  if (!Array.isArray(picks)) return [];
+
+  const validated: CuratedPick[] = [];
+  for (const entry of picks) {
+    if (!entry || typeof entry !== 'object') continue;
+    const pick = entry as Record<string, unknown>;
+    const url = pick['url'];
+    const mainTheme = pick['mainTheme'];
+    if (typeof url !== 'string' || typeof mainTheme !== 'string') continue;
+    if (!candidateUrls.has(url) || !themeNames.has(mainTheme)) {
+      console.warn(`[Trellis Curator] Dropped invalid pick: url=${url} mainTheme=${mainTheme}`);
+      continue;
+    }
+    validated.push({ url, mainTheme });
+    if (validated.length >= MAX_PICKS) break;
+  }
+  return validated;
+}
+
+function logPicks(
+  picks: readonly CuratedPick[],
+  rawPicks: readonly PickWithReason[],
+  candidateCount: number,
+): void {
+  console.log(`[Trellis Curator] Candidates: ${candidateCount}, Picks accepted: ${picks.length}`);
+  for (const pick of picks) {
+    const match = rawPicks.find((p) => p.url === pick.url);
+    const reason = match?.reason ?? '';
+    console.log(`[Trellis Curator] Pick: ${pick.url} (theme: ${pick.mainTheme}, reason: ${reason})`);
+  }
+  if (picks.length < MAX_PICKS) {
+    console.warn(`[Trellis Curator] Fewer than ${MAX_PICKS} picks survived validation (got ${picks.length}).`);
+  }
+}
+
+export async function curateTrellisArticles(
+  candidates: readonly TrellisCandidate[],
+  themeNames: readonly string[],
+  anthropicApiKey: string,
+): Promise<readonly CuratedPick[]> {
+  if (candidates.length === 0) return [];
+
+  const candidateUrls = new Set(candidates.map((c) => c.url));
+  const themeNameSet = new Set(themeNames);
+
+  let response: Response;
+  try {
+    response = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': anthropicApiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: buildUserPrompt(candidates, themeNames) }],
+      }),
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown';
+    console.error(`[Trellis Curator] fetch failed: ${message}`);
+    return [];
+  }
+
+  if (!response.ok) {
+    console.error(`[Trellis Curator] API returned ${response.status}`);
+    return [];
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    data = (await response.json()) as Record<string, unknown>;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown';
+    console.error(`[Trellis Curator] invalid response body: ${message}`);
+    return [];
+  }
+
+  const content = Array.isArray(data['content']) ? data['content'] : [];
+  const firstBlock = content[0] as Record<string, unknown> | undefined;
+  const rawText = typeof firstBlock?.['text'] === 'string' ? firstBlock['text'] : '';
+  if (!rawText) {
+    console.error('[Trellis Curator] empty content in response');
+    return [];
+  }
+
+  const parsed = parseClaudeText(rawText);
+  const validated = validatePicks(parsed, candidateUrls, themeNameSet);
+
+  const rawPicks: PickWithReason[] = [];
+  if (parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>)['picks'])) {
+    const rawList = (parsed as Record<string, unknown>)['picks'] as unknown[];
+    for (const entry of rawList) {
+      if (entry && typeof entry === 'object') {
+        const e = entry as Record<string, unknown>;
+        if (typeof e['url'] === 'string' && typeof e['mainTheme'] === 'string' && typeof e['reason'] === 'string') {
+          rawPicks.push({ url: e['url'], mainTheme: e['mainTheme'], reason: e['reason'] });
+        }
+      }
+    }
+  }
+
+  logPicks(validated, rawPicks, candidates.length);
+  return validated;
+}

--- a/apps/news-digest/pipeline/src/ai/trellis-curator.ts
+++ b/apps/news-digest/pipeline/src/ai/trellis-curator.ts
@@ -3,6 +3,7 @@ const ANTHROPIC_VERSION = '2023-06-01';
 const MODEL = 'claude-haiku-4-5-20251001';
 const MAX_TOKENS = 512;
 const MAX_PICKS = 2;
+const FETCH_TIMEOUT_MS = 15_000;
 
 export interface TrellisCandidate {
   readonly url: string;
@@ -109,9 +110,12 @@ export async function curateTrellisArticles(
   const themeNameSet = new Set(themeNames);
 
   let response: Response;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
     response = await fetch(ANTHROPIC_API_URL, {
       method: 'POST',
+      signal: controller.signal,
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': anthropicApiKey,
@@ -125,9 +129,14 @@ export async function curateTrellisArticles(
       }),
     });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'unknown';
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    const message = isAbort
+      ? `timeout after ${FETCH_TIMEOUT_MS}ms`
+      : (error instanceof Error ? error.message : 'unknown');
     console.error(`[Trellis Curator] fetch failed: ${message}`);
     return [];
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   if (!response.ok) {

--- a/apps/news-digest/pipeline/src/config.constants.ts
+++ b/apps/news-digest/pipeline/src/config.constants.ts
@@ -1,22 +1,22 @@
 import type { ThemeConfig } from './types.js';
 
 export const THEMES: readonly ThemeConfig[] = [
-  { name: 'Methane & Super Pollutants', frequency: 'daily', carbonPulseSearchTerms: 'methane', esgNewsSearchTerms: 'methane superpollutant' },
-  { name: 'Methane Detection & MRV', frequency: 'daily', carbonPulseSearchTerms: 'MRV monitoring measurement', esgNewsSearchTerms: 'methane detection monitoring MRV' },
-  { name: 'Circularity & Composting', frequency: 'daily', carbonPulseSearchTerms: 'waste recycling biochar composting', esgNewsSearchTerms: 'circular economy composting waste' },
-  { name: 'Global Events & COP30', frequency: 'daily', carbonPulseSearchTerms: 'COP30 Article 6 climate summit NDC', esgNewsSearchTerms: 'COP30 climate summit Paris Agreement' },
-  { name: 'Carrot Mentions', frequency: 'daily', carbonPulseSearchTerms: 'carrot BOLD circularity credits', esgNewsSearchTerms: 'carrot foundation BOLD' },
-  { name: 'Carbon Markets', frequency: 'weekly', carbonPulseSearchTerms: 'carbon market pricing ETS', esgNewsSearchTerms: 'carbon market credits pricing' },
-  { name: 'Corporate Carbon Credit Purchases', frequency: 'weekly', carbonPulseSearchTerms: 'corporate carbon credit purchase retirement', esgNewsSearchTerms: 'corporate carbon credit purchase' },
-  { name: 'Tokenized Carbon & Web3', frequency: 'weekly', carbonPulseSearchTerms: 'tokenized carbon blockchain digital', esgNewsSearchTerms: 'tokenized carbon blockchain' },
-  { name: 'Extended Producer Responsibility', frequency: 'weekly', carbonPulseSearchTerms: 'producer responsibility EPR', esgNewsSearchTerms: 'extended producer responsibility' },
-  { name: 'Waste Policy & Regulation', frequency: 'weekly', carbonPulseSearchTerms: 'waste regulation policy circular', esgNewsSearchTerms: 'waste policy regulation' },
-  { name: 'Composting Infrastructure', frequency: 'weekly', carbonPulseSearchTerms: 'composting infrastructure facility', esgNewsSearchTerms: 'composting infrastructure' },
-  { name: 'Climate Finance & AMC', frequency: 'weekly', carbonPulseSearchTerms: 'climate finance AMC investment', esgNewsSearchTerms: 'climate finance green bond' },
-  { name: 'Circularity Technology', frequency: 'weekly', carbonPulseSearchTerms: 'circularity technology traceability', esgNewsSearchTerms: 'circular technology traceability' },
-  { name: 'Social Impact & Inclusion', frequency: 'weekly', carbonPulseSearchTerms: 'social impact inclusion green jobs', esgNewsSearchTerms: 'social impact inclusion' },
-  { name: 'Verification & Auditing', frequency: 'monthly', carbonPulseSearchTerms: 'verification auditing integrity', esgNewsSearchTerms: 'ESG verification audit' },
-  { name: 'Circularity Investors', frequency: 'monthly', carbonPulseSearchTerms: 'circularity investor fund', esgNewsSearchTerms: 'circular economy investor fund' },
+  { name: 'Methane & Super Pollutants', frequency: 'daily', carbonPulseSearchTerms: 'methane', esgNewsSearchTerms: 'methane superpollutant', trellisSearchTerms: 'methane superpollutant refrigerant' },
+  { name: 'Methane Detection & MRV', frequency: 'daily', carbonPulseSearchTerms: 'MRV monitoring measurement', esgNewsSearchTerms: 'methane detection monitoring MRV', trellisSearchTerms: 'methane monitoring MRV measurement' },
+  { name: 'Circularity & Composting', frequency: 'daily', carbonPulseSearchTerms: 'waste recycling biochar composting', esgNewsSearchTerms: 'circular economy composting waste', trellisSearchTerms: 'circular economy composting waste' },
+  { name: 'Global Events & COP30', frequency: 'daily', carbonPulseSearchTerms: 'COP30 Article 6 climate summit NDC', esgNewsSearchTerms: 'COP30 climate summit Paris Agreement', trellisSearchTerms: 'COP30 climate summit' },
+  { name: 'Carrot Mentions', frequency: 'daily', carbonPulseSearchTerms: 'carrot BOLD circularity credits', esgNewsSearchTerms: 'carrot foundation BOLD', trellisSearchTerms: 'carrot foundation BOLD' },
+  { name: 'Carbon Markets', frequency: 'weekly', carbonPulseSearchTerms: 'carbon market pricing ETS', esgNewsSearchTerms: 'carbon market credits pricing', trellisSearchTerms: 'carbon market credits pricing' },
+  { name: 'Corporate Carbon Credit Purchases', frequency: 'weekly', carbonPulseSearchTerms: 'corporate carbon credit purchase retirement', esgNewsSearchTerms: 'corporate carbon credit purchase', trellisSearchTerms: 'corporate carbon credit purchase' },
+  { name: 'Tokenized Carbon & Web3', frequency: 'weekly', carbonPulseSearchTerms: 'tokenized carbon blockchain digital', esgNewsSearchTerms: 'tokenized carbon blockchain', trellisSearchTerms: 'tokenized carbon blockchain' },
+  { name: 'Extended Producer Responsibility', frequency: 'weekly', carbonPulseSearchTerms: 'producer responsibility EPR', esgNewsSearchTerms: 'extended producer responsibility', trellisSearchTerms: 'extended producer responsibility EPR' },
+  { name: 'Waste Policy & Regulation', frequency: 'weekly', carbonPulseSearchTerms: 'waste regulation policy circular', esgNewsSearchTerms: 'waste policy regulation', trellisSearchTerms: 'waste policy regulation' },
+  { name: 'Composting Infrastructure', frequency: 'weekly', carbonPulseSearchTerms: 'composting infrastructure facility', esgNewsSearchTerms: 'composting infrastructure', trellisSearchTerms: 'composting infrastructure facility' },
+  { name: 'Climate Finance & AMC', frequency: 'weekly', carbonPulseSearchTerms: 'climate finance AMC investment', esgNewsSearchTerms: 'climate finance green bond', trellisSearchTerms: 'climate finance green investment' },
+  { name: 'Circularity Technology', frequency: 'weekly', carbonPulseSearchTerms: 'circularity technology traceability', esgNewsSearchTerms: 'circular technology traceability', trellisSearchTerms: 'circular technology traceability' },
+  { name: 'Social Impact & Inclusion', frequency: 'weekly', carbonPulseSearchTerms: 'social impact inclusion green jobs', esgNewsSearchTerms: 'social impact inclusion', trellisSearchTerms: 'social impact inclusion green jobs' },
+  { name: 'Verification & Auditing', frequency: 'monthly', carbonPulseSearchTerms: 'verification auditing integrity', esgNewsSearchTerms: 'ESG verification audit', trellisSearchTerms: 'sustainability verification audit' },
+  { name: 'Circularity Investors', frequency: 'monthly', carbonPulseSearchTerms: 'circularity investor fund', esgNewsSearchTerms: 'circular economy investor fund', trellisSearchTerms: 'circular economy investor fund' },
 ] as const;
 
 export const FREQUENCY_DAYS: Readonly<Record<string, number>> = {

--- a/apps/news-digest/pipeline/src/distribution/__tests__/email-template.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/distribution/__tests__/email-template.helpers.spec.ts
@@ -46,6 +46,27 @@ describe('buildEmailHtml — render branches', () => {
     expect(html).toContain('<!-- Theme Section:');
     expect(html).not.toContain('<!-- Article Card -->');
   });
+
+  it('labels each source correctly in the compact branch (Trellis keeps its full name)', () => {
+    const articles = [
+      ...manyArticles(10),
+      stubProcessedArticle({
+        source: 'trellis',
+        url: 'https://trellis.net/article/x/',
+        title: 'Trellis compact pick',
+      }),
+      stubProcessedArticle({
+        source: 'esgnews',
+        url: 'https://esgnews.com/article/y/',
+        title: 'ESG compact pick',
+      }),
+    ];
+    const html = buildEmailHtml(articles, '2026-04-09');
+    // Each source's compact badge appears in the compact branch.
+    expect(html).toContain('>CP<');
+    expect(html).toContain('>ESG<');
+    expect(html).toContain('>Trellis<');
+  });
 });
 
 describe('buildEmailHtml — escaping', () => {

--- a/apps/news-digest/pipeline/src/distribution/email-template.helpers.ts
+++ b/apps/news-digest/pipeline/src/distribution/email-template.helpers.ts
@@ -1,4 +1,5 @@
 import type { ProcessedArticle } from '../types.js';
+import { sourceLabel } from '../helpers/source.helpers.js';
 
 function escapeHtml(text: string): string {
   return text
@@ -66,10 +67,6 @@ function themeColor(theme: string): string {
 
 function themeBgColor(theme: string): string {
   return (THEME_COLORS[theme] ?? DEFAULT_THEME).bgColor;
-}
-
-function sourceLabel(source: string): string {
-  return source === 'carbon-pulse' ? 'Carbon Pulse' : 'ESG News';
 }
 
 function formatDate(dateStr: string): string {

--- a/apps/news-digest/pipeline/src/distribution/email-template.helpers.ts
+++ b/apps/news-digest/pipeline/src/distribution/email-template.helpers.ts
@@ -1,5 +1,5 @@
 import type { ProcessedArticle } from '../types.js';
-import { sourceLabel } from '../helpers/source.helpers.js';
+import { sourceLabel, compactSourceLabel } from '../helpers/source.helpers.js';
 
 function escapeHtml(text: string): string {
   return text
@@ -181,7 +181,7 @@ function buildArticleCard(article: ProcessedArticle): string {
 function buildCompactArticleRow(article: ProcessedArticle): string {
   const url = articleUrl(article);
   const color = themeColor(article.mainTheme);
-  const srcLabel = sourceLabel(article.source) === 'Carbon Pulse' ? 'CP' : 'ESG';
+  const srcLabel = compactSourceLabel(article.source);
 
   return `
     <tr>

--- a/apps/news-digest/pipeline/src/distribution/notion.ts
+++ b/apps/news-digest/pipeline/src/distribution/notion.ts
@@ -1,5 +1,6 @@
 import type { ProcessedArticle } from '../types.js';
 import { NOTION_VALID_THEMES } from '../config.constants.js';
+import { sourceLabel } from '../helpers/source.helpers.js';
 
 interface NotionResult {
   readonly success: boolean;
@@ -20,7 +21,7 @@ function buildPageProperties(article: ProcessedArticle): Record<string, unknown>
     },
     // Trailing space in 'Source ' is intentional — matches the Notion database column name
     'Source ': {
-      rich_text: [{ text: { content: article.source === 'carbon-pulse' ? 'Carbon Pulse' : 'ESG News' } }],
+      rich_text: [{ text: { content: sourceLabel(article.source) } }],
     },
     Company: {
       rich_text: [{ text: { content: 'Not Applicable' } }],

--- a/apps/news-digest/pipeline/src/distribution/slack.ts
+++ b/apps/news-digest/pipeline/src/distribution/slack.ts
@@ -1,4 +1,5 @@
 import type { ProcessedArticle } from '../types.js';
+import { sourceLabel } from '../helpers/source.helpers.js';
 
 interface SlackBlock {
   type: string;
@@ -23,11 +24,6 @@ const MAX_ARTICLES = 15;
 
 function escapeSlackMrkdwn(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-function sourceLabel(source: ProcessedArticle['source']): string {
-  if (source === 'carbon-pulse') return 'Carbon Pulse';
-  return 'ESG News';
 }
 
 function articleUrl(article: ProcessedArticle): string {

--- a/apps/news-digest/pipeline/src/helpers/__tests__/dedup.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/dedup.helpers.spec.ts
@@ -51,4 +51,49 @@ describe('deduplicateArticles', () => {
     const result = deduplicateArticles([article1, article2]);
     expect(result.kept).toHaveLength(1);
   });
+
+  it('keeps Carbon Pulse over Trellis and ESG News for similar titles', () => {
+    const articles = [
+      stubArticle({ source: 'esgnews', url: 'https://esgnews.com/1/', title: 'EU carbon market hits record high' }),
+      stubArticle({ source: 'trellis', url: 'https://trellis.net/article/trl-1/', title: 'EU carbon market reaches record high' }),
+      stubArticle({ source: 'carbon-pulse', url: 'https://carbon-pulse.com/cp-1/', title: 'EU carbon market hits record high' }),
+    ];
+    const { kept, removed } = deduplicateArticles(articles);
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.source).toBe('carbon-pulse');
+    expect(removed).toHaveLength(2);
+  });
+
+  it('keeps Trellis over ESG News for similar titles', () => {
+    const articles = [
+      stubArticle({ source: 'esgnews', url: 'https://esgnews.com/2/', title: 'Methane emissions dropped in 2026' }),
+      stubArticle({ source: 'trellis', url: 'https://trellis.net/article/trl-2/', title: 'Methane emissions drop in 2026' }),
+    ];
+    const { kept, removed } = deduplicateArticles(articles);
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.source).toBe('trellis');
+    expect(removed).toHaveLength(1);
+    expect(removed[0]?.source).toBe('esgnews');
+  });
+
+  it('keeps distinct-title articles from all three sources', () => {
+    const articles = [
+      stubArticle({ source: 'carbon-pulse', url: 'https://carbon-pulse.com/a/', title: 'Alpha policy update' }),
+      stubArticle({ source: 'trellis', url: 'https://trellis.net/article/b/', title: 'Beta market analysis' }),
+      stubArticle({ source: 'esgnews', url: 'https://esgnews.com/c/', title: 'Gamma corporate news' }),
+    ];
+    const { kept, removed } = deduplicateArticles(articles);
+    expect(kept).toHaveLength(3);
+    expect(removed).toHaveLength(0);
+  });
+
+  it('removes a second article with the same URL regardless of source', () => {
+    const articles = [
+      stubArticle({ source: 'trellis', url: 'https://same.example/x/', title: 'First title' }),
+      stubArticle({ source: 'esgnews', url: 'https://same.example/x/', title: 'Unrelated title' }),
+    ];
+    const { kept, removed } = deduplicateArticles(articles);
+    expect(kept).toHaveLength(1);
+    expect(removed).toHaveLength(1);
+  });
 });

--- a/apps/news-digest/pipeline/src/helpers/__tests__/source.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/source.helpers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sourceLabel } from '../source.helpers.js';
+import { sourceLabel, compactSourceLabel } from '../source.helpers.js';
 
 describe('sourceLabel', () => {
   it.each<['carbon-pulse' | 'esgnews' | 'trellis', string]>([
@@ -8,5 +8,15 @@ describe('sourceLabel', () => {
     ['trellis', 'Trellis'],
   ])('maps %s to %s', (source, expected) => {
     expect(sourceLabel(source)).toBe(expected);
+  });
+});
+
+describe('compactSourceLabel', () => {
+  it.each<['carbon-pulse' | 'esgnews' | 'trellis', string]>([
+    ['carbon-pulse', 'CP'],
+    ['esgnews', 'ESG'],
+    ['trellis', 'Trellis'],
+  ])('maps %s to %s', (source, expected) => {
+    expect(compactSourceLabel(source)).toBe(expected);
   });
 });

--- a/apps/news-digest/pipeline/src/helpers/__tests__/source.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/source.helpers.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { sourceLabel } from '../source.helpers.js';
+
+describe('sourceLabel', () => {
+  it.each<['carbon-pulse' | 'esgnews' | 'trellis', string]>([
+    ['carbon-pulse', 'Carbon Pulse'],
+    ['esgnews', 'ESG News'],
+    ['trellis', 'Trellis'],
+  ])('maps %s to %s', (source, expected) => {
+    expect(sourceLabel(source)).toBe(expected);
+  });
+});

--- a/apps/news-digest/pipeline/src/helpers/dedup.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/dedup.helpers.ts
@@ -18,11 +18,19 @@ interface DedupResult {
   readonly removed: RawArticle[];
 }
 
+const SOURCE_PRIORITY: Record<RawArticle['source'], number> = {
+  'carbon-pulse': 0,
+  trellis: 1,
+  esgnews: 2,
+};
+
 export function deduplicateArticles(articles: readonly RawArticle[]): DedupResult {
   const kept: RawArticle[] = [];
   const removed: RawArticle[] = [];
   const seenUrls = new Set<string>();
-  const sorted = [...articles].sort((a, b) => a.source === 'carbon-pulse' && b.source !== 'carbon-pulse' ? -1 : 1);
+  const sorted = [...articles].sort(
+    (a, b) => SOURCE_PRIORITY[a.source] - SOURCE_PRIORITY[b.source],
+  );
 
   for (const article of sorted) {
     if (seenUrls.has(article.url)) { removed.push(article); continue; }

--- a/apps/news-digest/pipeline/src/helpers/markdown.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/markdown.helpers.ts
@@ -1,4 +1,5 @@
 import type { ProcessedArticle } from '../types.js';
+import { sourceLabel } from './source.helpers.js';
 
 const MAX_SLUG_LENGTH = 63;
 
@@ -11,10 +12,6 @@ export function slugify(title: string): string {
     .replace(/-+/g, '-')
     .slice(0, MAX_SLUG_LENGTH)
     .replace(/-$/, '');
-}
-
-function sourceLabel(source: string): string {
-  return source === 'carbon-pulse' ? 'Carbon Pulse' : 'ESG News';
 }
 
 export function buildArticleMarkdown(article: ProcessedArticle): string {

--- a/apps/news-digest/pipeline/src/helpers/source.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/source.helpers.ts
@@ -14,3 +14,18 @@ export function sourceLabel(source: RawArticle['source']): string {
     }
   }
 }
+
+export function compactSourceLabel(source: RawArticle['source']): string {
+  switch (source) {
+    case 'carbon-pulse':
+      return 'CP';
+    case 'esgnews':
+      return 'ESG';
+    case 'trellis':
+      return 'Trellis';
+    default: {
+      const _exhaustive: never = source;
+      return _exhaustive;
+    }
+  }
+}

--- a/apps/news-digest/pipeline/src/helpers/source.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/source.helpers.ts
@@ -1,0 +1,16 @@
+import type { RawArticle } from '../types.js';
+
+export function sourceLabel(source: RawArticle['source']): string {
+  switch (source) {
+    case 'carbon-pulse':
+      return 'Carbon Pulse';
+    case 'esgnews':
+      return 'ESG News';
+    case 'trellis':
+      return 'Trellis';
+    default: {
+      const _exhaustive: never = source;
+      return _exhaustive;
+    }
+  }
+}

--- a/apps/news-digest/pipeline/src/orchestrator.ts
+++ b/apps/news-digest/pipeline/src/orchestrator.ts
@@ -4,6 +4,7 @@ import { deduplicateArticles } from './helpers/dedup.helpers.js';
 import { buildArticleMarkdown, slugify } from './helpers/markdown.helpers.js';
 import { scrapeCarbonPulse } from './scraper/carbon-pulse.js';
 import { scrapeEsgNews } from './scraper/esg-news.js';
+import { scrapeTrellis } from './scraper/trellis.js';
 import { processArticle } from './ai/article-processor.js';
 import { postSlackDigest } from './distribution/slack.js';
 import { createNotionPage } from './distribution/notion.js';
@@ -249,24 +250,36 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     console.error(errors[errors.length - 1]);
   }
 
-  const allRaw = [...cpArticles, ...esgArticles];
+  // Step 5: Scrape Trellis
+  console.log('Step 5: Scraping Trellis...');
+  let trellisArticles: RawArticle[] = [];
+  try {
+    trellisArticles = await scrapeTrellis(eligibleThemes, processedUrls, config.secrets.anthropicApiKey);
+    console.log(`Trellis: ${trellisArticles.length} articles`);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'unknown';
+    errors.push(`Trellis scraping failed: ${msg}`);
+    console.error(errors[errors.length - 1]);
+  }
+
+  const allRaw = [...cpArticles, ...esgArticles, ...trellisArticles];
 
   if (allRaw.length === 0) {
     console.log('No articles scraped.');
     return {
-      steps: [], articlesScraped: 0, articlesBySource: { 'carbon-pulse': 0, esgnews: 0 },
+      steps: [], articlesScraped: 0, articlesBySource: { 'carbon-pulse': 0, esgnews: 0, trellis: 0 },
       deduped: 0, claudeProcessed: 0, claudeFallbacks: 0, notionCreated: 0, notionFailed: 0,
       emailDraftCreated: false, slackPosted: false, errors,
     };
   }
 
-  // Step 5: Dedup
-  console.log('Step 5: Cross-source dedup...');
+  // Step 6: Dedup
+  console.log('Step 6: Cross-source dedup...');
   const { kept, removed } = deduplicateArticles(allRaw);
   console.log(`Kept: ${kept.length}, Removed: ${removed.length}`);
 
-  // Step 6: Claude API — parallel with concurrency limit
-  console.log('Step 6: Processing articles with Claude API...');
+  // Step 7: Claude API — parallel with concurrency limit
+  console.log('Step 7: Processing articles with Claude API...');
   const processedArticles: ProcessedArticle[] = [];
   let claudeProcessed = 0;
   let claudeFallbacks = 0;
@@ -301,8 +314,8 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     }
   }
 
-  // Step 7: Save articles to S3 — parallel, individual failures don't crash pipeline
-  console.log('Step 7: Saving articles to S3...');
+  // Step 8: Save articles to S3 — parallel, individual failures don't crash pipeline
+  console.log('Step 8: Saving articles to S3...');
   const saveResults = await Promise.allSettled(
     processedArticles.map((article) => {
       const markdown = buildArticleMarkdown(article);
@@ -317,11 +330,11 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     }
   }
 
-  // Steps 8-10: Distribute
+  // Steps 9-11: Distribute
   const dist = await distributeArticles(processedArticles, config, today, errors, state);
 
-  // Step 11: Save final state — protected with error handling
-  console.log('Step 11: Saving final state to S3...');
+  // Step 12: Save final state — protected with error handling
+  console.log('Step 12: Saving final state to S3...');
   const updatedThemes = { ...state.themeLastProcessed };
   for (const theme of eligibleThemes) {
     updatedThemes[theme.name] = today;

--- a/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ThemeConfig } from '../../types.js';
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: vi.fn(),
+  },
+}));
+
+vi.mock('../../ai/trellis-curator.js', () => ({
+  curateTrellisArticles: vi.fn(),
+}));
+
+import { chromium } from 'playwright';
+import { curateTrellisArticles } from '../../ai/trellis-curator.js';
+import { scrapeTrellis } from '../trellis.js';
+
+const TODAY_ISO = new Date().toISOString().slice(0, 10);
+
+function stubTheme(overrides: Partial<ThemeConfig> = {}): ThemeConfig {
+  return {
+    name: 'Carbon Markets',
+    frequency: 'daily',
+    carbonPulseSearchTerms: 'carbon market',
+    esgNewsSearchTerms: 'carbon market',
+    trellisSearchTerms: 'carbon market',
+    ...overrides,
+  };
+}
+
+interface MockPageConfig {
+  gotoCalls?: string[];
+  evaluations?: Array<(url: string) => unknown>;
+}
+
+function mockBrowser(config: MockPageConfig) {
+  const gotoCalls: string[] = config.gotoCalls ?? [];
+  const evalQueue = [...(config.evaluations ?? [])];
+  const page = {
+    goto: vi.fn(async (url: string) => {
+      gotoCalls.push(url);
+      return null;
+    }),
+    evaluate: vi.fn(async (fn: () => unknown) => {
+      if (evalQueue.length === 0) return null;
+      const current = evalQueue.shift();
+      return current ? current(gotoCalls[gotoCalls.length - 1] ?? '') : null;
+    }),
+  };
+  const browser = {
+    newPage: vi.fn(async () => page),
+    close: vi.fn(async () => undefined),
+  };
+  vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+  return { browser, page, gotoCalls };
+}
+
+describe('scrapeTrellis', () => {
+  beforeEach(() => {
+    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extracts one article per theme using MAX_ARTICLES_PER_THEME=1', async () => {
+    mockBrowser({
+      evaluations: [
+        // Per-theme search page: list of article links.
+        () => [
+          { url: 'https://trellis.net/article/a1/', title: 'Article A1' },
+          { url: 'https://trellis.net/article/a2/', title: 'Article A2' },
+        ],
+        // Article A1 page: content + date + author.
+        () => ({
+          content: 'Full text of A1.',
+          date: TODAY_ISO,
+          author: 'Author A',
+        }),
+        // Homepage candidates (empty).
+        () => [],
+      ],
+    });
+    const result = await scrapeTrellis([stubTheme()], new Set(), 'test-key');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('trellis');
+    expect(result[0]?.url).toBe('https://trellis.net/article/a1/');
+    expect(result[0]?.title).toBe('Article A1');
+    expect(result[0]?.mainTheme).toBe('Carbon Markets');
+    expect(result[0]?.author).toBe('Author A');
+    expect(result[0]?.fullContent).toBe('Full text of A1.');
+  });
+
+  it('skips URLs already in processedUrls', async () => {
+    mockBrowser({
+      evaluations: [
+        () => [
+          { url: 'https://trellis.net/article/a1/', title: 'Already Seen' },
+          { url: 'https://trellis.net/article/a2/', title: 'Fresh' },
+        ],
+        () => ({ content: 'Fresh content.', date: TODAY_ISO, author: 'Author A2' }),
+        () => [],
+      ],
+    });
+    const seen = new Set(['https://trellis.net/article/a1/']);
+    const result = await scrapeTrellis([stubTheme()], seen, 'test-key');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.url).toBe('https://trellis.net/article/a2/');
+  });
+
+  it('skips articles older than MAX_ARTICLE_AGE_DAYS (30) days', async () => {
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    mockBrowser({
+      evaluations: [
+        () => [{ url: 'https://trellis.net/article/old/', title: 'Old' }],
+        () => ({ content: 'Old content.', date: oldDate, author: 'Old Author' }),
+        () => [],
+      ],
+    });
+    const result = await scrapeTrellis([stubTheme()], new Set(), 'test-key');
+    expect(result).toHaveLength(0);
+  });
+
+  it('falls back to default author "Trellis" when no author metadata is present', async () => {
+    mockBrowser({
+      evaluations: [
+        () => [{ url: 'https://trellis.net/article/a/', title: 'T' }],
+        () => ({ content: 'Content.', date: TODAY_ISO, author: '' }),
+        () => [],
+      ],
+    });
+    const result = await scrapeTrellis([stubTheme()], new Set(), 'test-key');
+    expect(result[0]?.author).toBe('Trellis');
+  });
+
+  it('falls back to today when no date metadata is present', async () => {
+    mockBrowser({
+      evaluations: [
+        () => [{ url: 'https://trellis.net/article/a/', title: 'T' }],
+        () => ({ content: 'Content.', date: '', author: 'A' }),
+        () => [],
+      ],
+    });
+    const result = await scrapeTrellis([stubTheme()], new Set(), 'test-key');
+    expect(result[0]?.date).toBe(TODAY_ISO);
+  });
+
+  it('adds curated picks returned by the curator as RawArticles', async () => {
+    mockBrowser({
+      evaluations: [
+        // Per-theme search returns no links.
+        () => [],
+        // Homepage candidates: two links with listing-DOM metadata.
+        () => [
+          { url: 'https://trellis.net/article/c1/', title: 'C1 title', date: TODAY_ISO, excerpt: 'C1 excerpt' },
+          { url: 'https://trellis.net/article/c2/', title: 'C2 title', date: TODAY_ISO, excerpt: 'C2 excerpt' },
+        ],
+        // Curated pick c1: full content fetch.
+        () => ({ content: 'C1 body.', date: TODAY_ISO, author: 'C1 Author' }),
+        // Curated pick c2: full content fetch.
+        () => ({ content: 'C2 body.', date: TODAY_ISO, author: 'C2 Author' }),
+      ],
+    });
+    vi.mocked(curateTrellisArticles).mockResolvedValueOnce([
+      { url: 'https://trellis.net/article/c1/', mainTheme: 'Carbon Markets' },
+      { url: 'https://trellis.net/article/c2/', mainTheme: 'Methane & Super Pollutants' },
+    ]);
+
+    const result = await scrapeTrellis([stubTheme()], new Set(), 'test-key');
+    expect(result).toHaveLength(2);
+    expect(result.map((a) => a.url)).toEqual([
+      'https://trellis.net/article/c1/',
+      'https://trellis.net/article/c2/',
+    ]);
+    expect(result[0]?.mainTheme).toBe('Carbon Markets');
+    expect(result[1]?.mainTheme).toBe('Methane & Super Pollutants');
+    expect(result.every((a) => a.source === 'trellis')).toBe(true);
+  });
+
+  it('returns only per-theme articles if the curator returns zero picks', async () => {
+    mockBrowser({
+      evaluations: [
+        () => [{ url: 'https://trellis.net/article/a/', title: 'A' }],
+        () => ({ content: 'Body.', date: TODAY_ISO, author: 'Author' }),
+        () => [
+          { url: 'https://trellis.net/article/c/', title: 'C', date: TODAY_ISO, excerpt: 'C excerpt' },
+        ],
+      ],
+    });
+    vi.mocked(curateTrellisArticles).mockResolvedValueOnce([]);
+
+    const result = await scrapeTrellis([stubTheme()], new Set(), 'test-key');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.url).toBe('https://trellis.net/article/a/');
+  });
+
+  it('returns only per-theme articles if homepage fetch throws', async () => {
+    const { page } = mockBrowser({
+      evaluations: [
+        () => [{ url: 'https://trellis.net/article/a/', title: 'A' }],
+        () => ({ content: 'Body.', date: TODAY_ISO, author: 'Author' }),
+      ],
+    });
+    // After the per-theme article page.goto + evaluate pair, the 3rd goto is for the homepage.
+    // Make that goto reject.
+    let gotoCount = 0;
+    page.goto.mockImplementation(async (url: string) => {
+      gotoCount += 1;
+      if (gotoCount >= 3) throw new Error('homepage unreachable');
+      return null;
+    });
+
+    const result = await scrapeTrellis([stubTheme()], new Set(), 'test-key');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.url).toBe('https://trellis.net/article/a/');
+    expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
+  });
+
+  it('passes all themes (from THEMES config) as allowedThemes to the curator, not just eligible ones', async () => {
+    mockBrowser({
+      evaluations: [
+        // Eligible theme 1 search → empty.
+        () => [],
+        // Eligible theme 2 search → empty.
+        () => [],
+        // Homepage listing → one candidate with listing-DOM metadata.
+        () => [
+          { url: 'https://trellis.net/article/c/', title: 'C', date: TODAY_ISO, excerpt: 'ex' },
+        ],
+      ],
+    });
+    vi.mocked(curateTrellisArticles).mockResolvedValueOnce([]);
+
+    const eligibleThemes = [
+      stubTheme({ name: 'Carbon Markets' }),
+      stubTheme({ name: 'Methane Detection & MRV' }),
+    ];
+    await scrapeTrellis(eligibleThemes, new Set(), 'test-key');
+
+    expect(vi.mocked(curateTrellisArticles)).toHaveBeenCalledTimes(1);
+    const [, themeNames] = vi.mocked(curateTrellisArticles).mock.calls[0]!;
+    // Curator receives the full THEMES list, not just the two eligible ones.
+    // Assert length and presence of themes outside the eligible set.
+    expect(themeNames.length).toBeGreaterThan(eligibleThemes.length);
+    expect(themeNames).toContain('Carbon Markets');
+    expect(themeNames).toContain('Methane Detection & MRV');
+    expect(themeNames).toContain('Verification & Auditing'); // monthly theme, typically not eligible daily
+  });
+
+  it('closes the browser in a finally block even when scraping throws', async () => {
+    const { browser } = mockBrowser({ evaluations: [] });
+    vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+    browser.newPage.mockRejectedValueOnce(new Error('page creation failed'));
+
+    await expect(scrapeTrellis([stubTheme()], new Set(), 'test-key')).rejects.toThrow('page creation failed');
+    expect(browser.close).toHaveBeenCalled();
+  });
+});

--- a/apps/news-digest/pipeline/src/scraper/trellis.ts
+++ b/apps/news-digest/pipeline/src/scraper/trellis.ts
@@ -1,0 +1,295 @@
+import { chromium } from 'playwright';
+import type { Browser, Page } from 'playwright';
+import { THEMES } from '../config.constants.js';
+import { curateTrellisArticles, type TrellisCandidate } from '../ai/trellis-curator.js';
+import type { RawArticle, ThemeConfig } from '../types.js';
+
+const SEARCH_URL = 'https://trellis.net/?s=';
+const LISTING_URL = 'https://trellis.net/articles/';
+const HOMEPAGE_URL = 'https://trellis.net/';
+const MAX_ARTICLES_PER_THEME = 1;
+const MAX_ARTICLE_AGE_DAYS = 30;
+const CANDIDATE_POOL_SIZE = 15;
+const MAX_EXCERPT_LENGTH = 400;
+
+interface SearchLink {
+  readonly url: string;
+  readonly title: string;
+}
+
+interface ArticleExtract {
+  readonly content: string;
+  readonly date: string;
+  readonly author: string;
+}
+
+interface ListingItem {
+  readonly url: string;
+  readonly title: string;
+  readonly date: string;   // may be empty if not in listing DOM
+  readonly excerpt: string; // may be empty if not in listing DOM
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isTooOld(dateIso: string): boolean {
+  const ts = new Date(dateIso).getTime();
+  if (Number.isNaN(ts)) return false;
+  return Date.now() - ts > MAX_ARTICLE_AGE_DAYS * 24 * 60 * 60 * 1000;
+}
+
+async function extractSearchLinks(page: Page): Promise<SearchLink[]> {
+  return page.evaluate(() => {
+    const anchors = Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href*="/article/"]'));
+    const seen = new Set<string>();
+    const out: SearchLink[] = [];
+    for (const a of anchors) {
+      const href = a.href;
+      if (!href || seen.has(href)) continue;
+      const title = (a.textContent ?? '').trim();
+      if (!title) continue;
+      seen.add(href);
+      out.push({ url: href, title });
+    }
+    return out;
+  });
+}
+
+async function extractArticle(page: Page): Promise<ArticleExtract> {
+  return page.evaluate(() => {
+    const container =
+      document.querySelector('article') ??
+      document.querySelector('main') ??
+      document.body;
+    const content = (container?.textContent ?? '').trim();
+
+    const publishedMeta = document
+      .querySelector('meta[property="article:published_time"]')
+      ?.getAttribute('content') ?? '';
+    const timeAttr = document.querySelector('time')?.getAttribute('datetime') ?? '';
+    const date = (publishedMeta || timeAttr).slice(0, 10);
+
+    const authorMeta = document.querySelector('meta[name="author"]')?.getAttribute('content') ?? '';
+    const bylineEl = document.querySelector('.author, .byline, [rel="author"]');
+    const author = authorMeta || (bylineEl?.textContent ?? '').trim();
+
+    return { content, date, author };
+  });
+}
+
+async function extractListing(page: Page): Promise<ListingItem[]> {
+  return page.evaluate((maxExcerpt: number) => {
+    const anchors = Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href*="/article/"]'));
+    const seen = new Set<string>();
+    const out: ListingItem[] = [];
+    for (const a of anchors) {
+      const href = a.href;
+      if (!href || seen.has(href)) continue;
+      const title = (a.textContent ?? '').trim();
+      if (!title) continue;
+      // Probe for adjacent date/excerpt in the listing DOM.
+      const card = a.closest('article, li, .post, .card') ?? a.parentElement;
+      const timeAttr = card?.querySelector('time')?.getAttribute('datetime') ?? '';
+      const dekEl = card?.querySelector('.dek, .excerpt, .summary, p');
+      const excerpt = ((dekEl?.textContent ?? '').trim()).slice(0, maxExcerpt);
+      seen.add(href);
+      out.push({ url: href, title, date: timeAttr.slice(0, 10), excerpt });
+    }
+    return out;
+  }, MAX_EXCERPT_LENGTH);
+}
+
+async function scrapeThemeSearch(
+  page: Page,
+  theme: ThemeConfig,
+  processedUrls: ReadonlySet<string>,
+): Promise<RawArticle[]> {
+  const searchUrl = `${SEARCH_URL}${encodeURIComponent(theme.trellisSearchTerms)}`;
+  try {
+    await page.goto(searchUrl, { waitUntil: 'domcontentloaded' });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown';
+    console.error(`[Trellis] Theme search failed for "${theme.name}": ${message}`);
+    return [];
+  }
+
+  const links = await extractSearchLinks(page);
+  const fresh = links.filter((l) => !processedUrls.has(l.url)).slice(0, MAX_ARTICLES_PER_THEME);
+
+  const articles: RawArticle[] = [];
+  for (const link of fresh) {
+    try {
+      await page.goto(link.url, { waitUntil: 'domcontentloaded' });
+      const extracted = await extractArticle(page);
+      const date = extracted.date || todayIso();
+      if (isTooOld(date)) {
+        console.warn(`[Trellis] Article too old (${date}), skipping: ${link.url}`);
+        continue;
+      }
+      articles.push({
+        source: 'trellis',
+        url: link.url,
+        title: link.title,
+        date,
+        author: extracted.author || 'Trellis',
+        mainTheme: theme.name,
+        categories: '',
+        location: '',
+        fullContent: extracted.content,
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'unknown';
+      console.error(`[Trellis] Failed to extract "${link.title}": ${message}`);
+    }
+  }
+  return articles;
+}
+
+async function fetchCandidateMetadata(
+  page: Page,
+  item: ListingItem,
+): Promise<TrellisCandidate | null> {
+  // Happy path: listing DOM supplied both date and excerpt.
+  if (item.date && item.excerpt) {
+    if (isTooOld(item.date)) return null;
+    return { url: item.url, title: item.title, date: item.date, excerpt: item.excerpt };
+  }
+
+  // Fallback: navigate to the article to read meta tags.
+  try {
+    await page.goto(item.url, { waitUntil: 'domcontentloaded' });
+    const extracted = await page.evaluate((maxExcerpt: number) => {
+      const publishedMeta = document
+        .querySelector('meta[property="article:published_time"]')
+        ?.getAttribute('content') ?? '';
+      const timeAttr = document.querySelector('time')?.getAttribute('datetime') ?? '';
+      const date = (publishedMeta || timeAttr).slice(0, 10);
+      const descMeta = document.querySelector('meta[name="description"]')?.getAttribute('content') ?? '';
+      const firstP = document.querySelector('article p')?.textContent ?? '';
+      const excerpt = (descMeta || firstP).trim().slice(0, maxExcerpt);
+      return { date, excerpt };
+    }, MAX_EXCERPT_LENGTH);
+    const date = extracted.date || todayIso();
+    if (isTooOld(date)) return null;
+    return {
+      url: item.url,
+      title: item.title,
+      date,
+      excerpt: extracted.excerpt,
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown';
+    console.warn(`[Trellis] Candidate metadata fetch failed for ${item.url}: ${message}`);
+    return null;
+  }
+}
+
+async function collectHomepageCandidates(
+  page: Page,
+  excludeUrls: ReadonlySet<string>,
+): Promise<TrellisCandidate[]> {
+  // Prefer /articles/ listing; fall back to homepage.
+  let listingLoaded = false;
+  try {
+    await page.goto(LISTING_URL, { waitUntil: 'domcontentloaded' });
+    listingLoaded = true;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown';
+    console.warn(`[Trellis] /articles/ listing unavailable (${message}), falling back to homepage`);
+  }
+
+  if (!listingLoaded) {
+    await page.goto(HOMEPAGE_URL, { waitUntil: 'domcontentloaded' });
+  }
+
+  const items = await extractListing(page);
+  const fresh = items
+    .filter((item) => !excludeUrls.has(item.url))
+    .slice(0, CANDIDATE_POOL_SIZE);
+
+  const candidates: TrellisCandidate[] = [];
+  for (const item of fresh) {
+    const candidate = await fetchCandidateMetadata(page, item);
+    if (candidate) candidates.push(candidate);
+  }
+  return candidates;
+}
+
+async function scrapeCuratedPick(
+  page: Page,
+  candidate: TrellisCandidate,
+  mainTheme: string,
+): Promise<RawArticle | null> {
+  try {
+    await page.goto(candidate.url, { waitUntil: 'domcontentloaded' });
+    const extracted = await extractArticle(page);
+    const date = extracted.date || candidate.date || todayIso();
+    if (isTooOld(date)) {
+      console.warn(`[Trellis] Curated pick too old (${date}), skipping: ${candidate.url}`);
+      return null;
+    }
+    return {
+      source: 'trellis',
+      url: candidate.url,
+      title: candidate.title,
+      date,
+      author: extracted.author || 'Trellis',
+      mainTheme,
+      categories: '',
+      location: '',
+      fullContent: extracted.content,
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown';
+    console.error(`[Trellis] Failed to extract curated pick ${candidate.url}: ${message}`);
+    return null;
+  }
+}
+
+export async function scrapeTrellis(
+  themes: readonly ThemeConfig[],
+  processedUrls: ReadonlySet<string>,
+  anthropicApiKey: string,
+): Promise<RawArticle[]> {
+  const browser: Browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+
+    const perTheme: RawArticle[] = [];
+    for (const theme of themes) {
+      console.log(`[Trellis] Searching: ${theme.name}`);
+      const themeArticles = await scrapeThemeSearch(page, theme, processedUrls);
+      perTheme.push(...themeArticles);
+      console.log(`[Trellis] Found ${themeArticles.length} article(s) for ${theme.name}`);
+    }
+
+    const exclude = new Set<string>([...processedUrls, ...perTheme.map((a) => a.url)]);
+    let curated: RawArticle[] = [];
+    try {
+      const candidates = await collectHomepageCandidates(page, exclude);
+      if (candidates.length > 0) {
+        const candidateByUrl = new Map(candidates.map((c) => [c.url, c]));
+        const allThemeNames = THEMES.map((t) => t.name);
+        const picks = await curateTrellisArticles(candidates, allThemeNames, anthropicApiKey);
+        for (const pick of picks) {
+          const candidate = candidateByUrl.get(pick.url);
+          if (!candidate) continue;
+          const article = await scrapeCuratedPick(page, candidate, pick.mainTheme);
+          if (article) curated.push(article);
+        }
+      } else {
+        console.warn('[Trellis] No homepage candidates collected; skipping curation.');
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'unknown';
+      console.warn(`[Trellis] Curation flow failed: ${message}`);
+      curated = [];
+    }
+
+    return [...perTheme, ...curated];
+  } finally {
+    await browser.close();
+  }
+}

--- a/apps/news-digest/pipeline/src/scraper/trellis.ts
+++ b/apps/news-digest/pipeline/src/scraper/trellis.ts
@@ -205,14 +205,12 @@ async function collectHomepageCandidates(
   }
 
   const items = await extractListing(page);
-  const fresh = items
-    .filter((item) => !excludeUrls.has(item.url))
-    .slice(0, CANDIDATE_POOL_SIZE);
-
   const candidates: TrellisCandidate[] = [];
-  for (const item of fresh) {
+  for (const item of items) {
+    if (excludeUrls.has(item.url)) continue;
     const candidate = await fetchCandidateMetadata(page, item);
     if (candidate) candidates.push(candidate);
+    if (candidates.length >= CANDIDATE_POOL_SIZE) break;
   }
   return candidates;
 }

--- a/apps/news-digest/pipeline/src/types.ts
+++ b/apps/news-digest/pipeline/src/types.ts
@@ -1,5 +1,5 @@
 export interface RawArticle {
-  readonly source: 'carbon-pulse' | 'esgnews';
+  readonly source: 'carbon-pulse' | 'esgnews' | 'trellis';
   readonly url: string;
   readonly title: string;
   readonly date: string;
@@ -11,7 +11,7 @@ export interface RawArticle {
 }
 
 export interface ProcessedArticle {
-  readonly source: 'carbon-pulse' | 'esgnews';
+  readonly source: 'carbon-pulse' | 'esgnews' | 'trellis';
   readonly url: string;
   readonly title: string;
   readonly date: string;
@@ -42,6 +42,7 @@ export interface ThemeConfig {
   readonly frequency: ThemeFrequency;
   readonly carbonPulseSearchTerms: string;
   readonly esgNewsSearchTerms: string;
+  readonly trellisSearchTerms: string;
 }
 
 export type StepName =
@@ -49,6 +50,7 @@ export type StepName =
   | 'theme-selection'
   | 'scrape-carbon-pulse'
   | 'scrape-esg-news'
+  | 'scrape-trellis'
   | 'dedup'
   | 'ai-process'
   | 'save-articles'

--- a/cspell.json
+++ b/cspell.json
@@ -35,7 +35,8 @@
     "hashicorp",
     "xvfb",
     "Xvfb",
-    "KHTML"
+    "KHTML",
+    "unstub"
   ],
   "dictionaries": [
     "companies",


### PR DESCRIPTION
### Summary

Adds `trellis.net` (formerly GreenBiz) as a third data source in the daily news-digest pipeline, alongside Carbon Pulse and ESG News. Each run pulls **1 article per eligible theme** via search, plus **2 homepage articles curated by Claude** and tagged with a `mainTheme` from the full `THEMES` allowlist.

Also includes a DRY consolidation of the duplicated `sourceLabel()` helpers (four call sites, binary ternaries that silently defaulted to `"ESG News"`) into a single exhaustive-switch helper in `helpers/source.helpers.ts`.

### Details

**New scraper — `scraper/trellis.ts`**
- Playwright, headless, no auth, no proxy (Trellis is fully open).
- Per-theme search: `https://trellis.net/?s=<terms>` → 1 article per eligible theme (`MAX_ARTICLES_PER_THEME = 1`).
- Homepage candidate collection: prefers `/articles/`, falls back to `/` if listing shape is unexpected. Up to 15 candidates after deduping against per-theme URLs and S3-state `processedUrls`.
- Listing-DOM date/excerpt extraction as happy path; per-candidate navigation only when listing DOM omits them (max 1 navigation per candidate).
- Date extraction: `meta[property="article:published_time"]` → `<time datetime>` → today. Author: `meta[name="author"]` → `.author/.byline/[rel="author"]` → `"Trellis"`. Age filter: 30 days.

**New curator — `ai/trellis-curator.ts`**
- Single Claude Haiku 4.5 call (aligned with existing `article-processor.ts`).
- Strict deterministic validation: picks must have a URL that exists in the candidate pool AND a `mainTheme` that matches the provided allowlist. Invalid picks are dropped (not thrown).
- All failure modes (fetch error, non-2xx, malformed JSON, missing `picks`) return `[]` — the pipeline ships per-theme articles regardless.
- Short-circuits with zero API cost when candidates are empty.
- Receives **all** `THEMES.map(t => t.name)`, not just eligible themes: curation is a classification task, not an eligibility decision. A curated article about Carbon Markets on a non-Carbon-Markets day stays tagged "Carbon Markets".

**Dedup priority** — `helpers/dedup.helpers.ts`
- New order: Carbon Pulse (0) > Trellis (1) > ESG News (2). Uses a `Record<RawArticle['source'], number>` map so TypeScript enforces exhaustiveness.
- Drive-by fix: replaces the previous `±1`-only comparator (non-transitive) with a proper subtraction-based sort.

**DRY consolidation** — new `helpers/source.helpers.ts`
- Single `sourceLabel(source: RawArticle['source']): string` with exhaustive `switch` + `never` default. Any future source addition becomes a **compile-time error**.
- Replaces duplicated implementations in `distribution/slack.ts`, `distribution/email-template.helpers.ts`, `helpers/markdown.helpers.ts`, and an inlined ternary in `distribution/notion.ts`.

**Orchestrator wiring** — `orchestrator.ts`
- New Step 5 (Scrape Trellis) between ESG News scrape and dedup.
- Subsequent step numbers shifted: dedup 5→6, Claude processing 6→7, save articles 7→8, distribute 8–10→9–11, save state 11→12.
- Trellis failures are isolated to its own try/catch — a broken Trellis scrape does not stop the pipeline.

### Testing

**All 85 tests pass** (up from 58 on main; 27 new test cases).

Reviewer verification:

```bash
# Full pipeline suite
pnpm vitest run apps/news-digest/pipeline

# Individual new suites
pnpm vitest run apps/news-digest/pipeline/src/helpers/__tests__/source.helpers.spec.ts
pnpm vitest run apps/news-digest/pipeline/src/helpers/__tests__/dedup.helpers.spec.ts
pnpm vitest run apps/news-digest/pipeline/src/ai/__tests__/trellis-curator.spec.ts
pnpm vitest run apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts

# Build
pnpm nx build news-digest-pipeline
```

Coverage highlights:
- **Scraper (10 tests):** per-theme extraction with MAX=1, processedUrls skip, 30-day age filter, author/date fallbacks, 2 curated picks flow, zero picks fallback, homepage-fetch failure isolation, "all themes" assertion (curator receives full `THEMES`, not just eligible), browser closed in `finally` even on throw.
- **Curator (10 tests):** empty-input short-circuit (no API call), valid picks, URL-not-in-pool filter, theme-not-in-allowlist filter, `MAX_PICKS` cap, non-JSON/malformed/missing-field tolerance, fetch rejection, non-2xx status, markdown-fence tolerance.
- **Dedup (4 new tests):** Carbon Pulse > Trellis > ESG News priority, Trellis > ESG News for similar titles, three distinct sources all kept, cross-source URL dedup.

### Known pre-existing issues (not in scope)

These existed on `main` before this PR and were not caused by these changes:

- `distribution/notion.ts:102` — `exactOptionalPropertyTypes` clash on `pageId`.
- `scraper/esg-news.ts:2` — unused `Browser` import.
- `pnpm nx lint news-digest-pipeline` fails with `Unable to resolve @nx/linter:eslint` (legacy executor name in inferred Nx target; `nx.json` uses `@nx/eslint/plugin`). Worth a separate infra ticket.

### Deployment notes

No new secrets required — the curator reuses `config.secrets.anthropicApiKey` that already exists. No schema or state migration: the `source` union expands from `'carbon-pulse' | 'esgnews'` to include `'trellis'`, and existing S3 state (which only has the first two) remains valid.

First production run to watch for:
- `[Trellis Curator] Candidates: N, Picks accepted: M` log line.
- Warnings about dropped invalid picks (indicates prompt-quality regression; tune `SYSTEM_PROMPT` if sustained).
- `Trellis: <N> articles` count in the summary — expect N = eligible-themes-count + up to 2.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Playwright-based scraper and an Anthropic curation call, introducing new external I/O and AI-dependent behavior that could affect pipeline reliability and article selection. Changes also touch cross-source deduplication and distribution labeling logic across Slack/Email/Notion/Markdown.
> 
> **Overview**
> Adds `trellis` as a third source in the news-digest pipeline: a new Playwright scraper pulls **1 article per eligible theme** plus a homepage candidate pool, then calls a new Anthropic curator to select up to **2 additional picks** and tags them with an allowlisted `mainTheme`.
> 
> Wires Trellis into the orchestrator (new scrape step and updated per-source counts), expands `RawArticle`/`ProcessedArticle` source unions and `ThemeConfig` to include `trellisSearchTerms`, and updates deduplication to a stable priority order (**Carbon Pulse > Trellis > ESG News**).
> 
> Consolidates duplicated source-name formatting into `helpers/source.helpers.ts` (including compact email badges) and adds comprehensive tests around Trellis scraping/curation, dedup priority, and source labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44543a8858d9f241e280d07afd0ced8e05902562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->