### PR TITLE
fix(news-digest): scope Trellis extraction to .post-content

### DIFF
--- a/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
@@ -13,7 +13,7 @@ vi.mock('../../ai/trellis-curator.js', () => ({
 
 import { chromium } from 'playwright';
 import { curateTrellisArticles } from '../../ai/trellis-curator.js';
-import { scrapeTrellis } from '../trellis.js';
+import { scrapeTrellis, TRELLIS_CONTENT_SELECTORS } from '../trellis.js';
 
 const TODAY_ISO = new Date().toISOString().slice(0, 10);
 
@@ -246,6 +246,17 @@ describe('scrapeTrellis', () => {
     expect(themeNames).toContain('Carbon Markets');
     expect(themeNames).toContain('Methane Detection & MRV');
     expect(themeNames).toContain('Verification & Auditing'); // monthly theme, typically not eligible daily
+  });
+
+  it('prefers .post-content over <article> to keep sidebar/author/related widgets out of the body (regression)', () => {
+    // <article class="post-type-post"> on Trellis wraps the article header,
+    // byline, image caption, author bio, newsletter signup, "Featured Reports",
+    // "Coming up" and "Recommended" widgets. Scoping to .post-content first is
+    // what isolates the actual article body. If this list ever drops or
+    // demotes .post-content, articles will again render with sidebar bleed and
+    // huge whitespace runs (the "black areas" bug in Notion).
+    expect(TRELLIS_CONTENT_SELECTORS[0]).toBe('.post-content');
+    expect(TRELLIS_CONTENT_SELECTORS).toContain('article');
   });
 
   it('produces clean paragraph text from CSS-layout whitespace (regression)', async () => {

--- a/apps/news-digest/pipeline/src/scraper/trellis.ts
+++ b/apps/news-digest/pipeline/src/scraper/trellis.ts
@@ -12,6 +12,12 @@ const MAX_ARTICLE_AGE_DAYS = 30;
 const CANDIDATE_POOL_SIZE = 15;
 const MAX_EXCERPT_LENGTH = 400;
 
+export const TRELLIS_CONTENT_SELECTORS = [
+  '.post-content',
+  'article',
+  'main',
+] as const;
+
 interface SearchLink {
   readonly url: string;
   readonly title: string;
@@ -58,21 +64,25 @@ async function extractSearchLinks(page: Page): Promise<SearchLink[]> {
 }
 
 async function extractArticle(page: Page): Promise<ArticleExtract> {
-  return page.evaluate(() => {
-    const container =
-      document.querySelector('article') ??
-      document.querySelector('main') ??
-      document.body;
+  return page.evaluate((selectors: readonly string[]) => {
+    // Trellis wraps the article header, byline, image caption, author bio,
+    // newsletter signup, "Featured Reports", "Coming up" and "Recommended"
+    // widgets all inside <article class="post-type-post">. Scoping to
+    // .post-content (the body div) is what keeps sidebar paragraphs out.
+    let container: Element | null = null;
+    for (const selector of selectors) {
+      container = document.querySelector(selector);
+      if (container) break;
+    }
+    container = container ?? document.body;
 
-    // Walk <p> elements and trim each paragraph individually to avoid capturing
-    // raw whitespace produced by CSS-laid-out HTML (flex/grid containers emit
-    // long runs of spaces/tabs between text nodes when using textContent).
-    const paragraphs = Array.from(container?.querySelectorAll('p') ?? [])
-      .map((paragraph) => (paragraph.textContent ?? '').trim())
+    // Collapse internal whitespace runs so any sidebar <p> that slips through
+    // a future selector change cannot reintroduce tab/space blocks.
+    const paragraphs = Array.from(container.querySelectorAll('p'))
+      .map((paragraph) => (paragraph.textContent ?? '').replace(/\s+/g, ' ').trim())
       .filter((text) => text.length > 0);
-    const content = paragraphs.length > 0
-      ? paragraphs.join('\n\n')
-      : (container?.textContent ?? '').trim();
+    const fallback = (container.textContent ?? '').replace(/\s+/g, ' ').trim();
+    const content = paragraphs.length > 0 ? paragraphs.join('\n\n') : fallback;
 
     const publishedMeta = document
       .querySelector('meta[property="article:published_time"]')
@@ -85,7 +95,7 @@ async function extractArticle(page: Page): Promise<ArticleExtract> {
     const author = authorMeta || (bylineEl?.textContent ?? '').trim();
 
     return { content, date, author };
-  });
+  }, [...TRELLIS_CONTENT_SELECTORS]);
 }
 
 async function extractListing(page: Page): Promise<ListingItem[]> {


### PR DESCRIPTION
## Summary
- Trellis wraps the article header card, author bio, newsletter signup, *Featured Reports*, *Coming up* events, sidebar and *Recommended* widgets all inside `<article class=\"post-type-post\">`. The previous `<p>` walk inside `<article>` therefore scraped paragraphs from every sub-section, and the header card uses CSS flex/grid whose text nodes are separated by tabs that survived `.trim()` — Notion rendered those tabs as visible empty space (the *black areas* bug seen on Apr 23 + Apr 20 articles).
- Prefer `.post-content` (the body div) before falling back to `article`/`main`. Verified empirically: `.post-content` contains zero newsletter / featured-resources / coming-up / article-author / sidebar / wpforms occurrences.
- Defense in depth: collapse internal whitespace (`/\s+/g → ' '`) inside each paragraph so a future selector change can't reintroduce tab runs.
- Exported `TRELLIS_CONTENT_SELECTORS` and added a regression test asserting `.post-content` stays first in the selector list.

## Test plan
- [x] `npx vitest run` in `apps/news-digest/pipeline` — 94/94 passing
- [x] Re-extracted clean content via the new selector for both affected Trellis URLs and confirmed sidebar/footer text is gone
- [x] Manually rebuilt the two existing Notion pages with the cleaned content; re-fetch shows no whitespace runs and sectioned headings render correctly
- [ ] Next pipeline run (orchestrator → Trellis curator) should produce clean article bodies with no manual intervention

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Trellis article-body extraction and whitespace normalization, which could alter or reduce scraped content if selectors miss new page layouts. Scope is limited to the Trellis scraper and adds regression coverage to mitigate breakage.
> 
> **Overview**
> Fixes Trellis scraping to **prefer `.post-content`** (then fall back to `article`/`main`) when extracting article bodies, reducing capture of sidebar/byline/newsletter/related-widget text.
> 
> Adds defense-in-depth whitespace normalization by collapsing internal whitespace runs in paragraph and fallback text extraction, and exports `TRELLIS_CONTENT_SELECTORS` with a regression test to ensure `.post-content` remains the first-choice selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826efdb3649825ebdc8eeee751fda5edc21dca52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->