### PR TITLE
track a16z crypto newsletter via substack rss

### DIFF
--- a/apps/news-digest/pipeline/src/config.constants.ts
+++ b/apps/news-digest/pipeline/src/config.constants.ts
@@ -53,6 +53,7 @@ export const NOTION_VALID_THEMES = [
   'Carbon Markets',
   'Extended Producer Responsibility',
   'Global Events & COP30',
+  'Industry Intelligence',
 ] as const;
 
 export const SUBSTACK_PUBLICATIONS: readonly SubstackPublication[] = [

--- a/apps/news-digest/pipeline/src/config.constants.ts
+++ b/apps/news-digest/pipeline/src/config.constants.ts
@@ -1,4 +1,4 @@
-import type { ThemeConfig } from './types.js';
+import type { ThemeConfig, SubstackPublication } from './types.js';
 
 export const THEMES: readonly ThemeConfig[] = [
   { name: 'Methane & Super Pollutants', frequency: 'daily', carbonPulseSearchTerms: 'methane', esgNewsSearchTerms: 'methane superpollutant', trellisSearchTerms: 'methane superpollutant refrigerant' },
@@ -54,3 +54,11 @@ export const NOTION_VALID_THEMES = [
   'Extended Producer Responsibility',
   'Global Events & COP30',
 ] as const;
+
+export const SUBSTACK_PUBLICATIONS: readonly SubstackPublication[] = [
+  {
+    name: 'a16z crypto',
+    source: 'a16z-crypto',
+    feedUrl: 'https://a16zcrypto.substack.com/feed',
+  },
+];

--- a/apps/news-digest/pipeline/src/config.schema.ts
+++ b/apps/news-digest/pipeline/src/config.schema.ts
@@ -41,7 +41,7 @@ export type Env = z.infer<typeof envSchema>;
 
 export const processedStateSchema = z.object({
   processedArticles: z.array(z.object({
-    source: z.enum(['carbon-pulse', 'esgnews', 'trellis']).default('carbon-pulse'),
+    source: z.enum(['carbon-pulse', 'esgnews', 'trellis', 'a16z-crypto']).default('carbon-pulse'),
     url: z.string().url(),
     title: z.string(),
     date: z.string(),

--- a/apps/news-digest/pipeline/src/helpers/__tests__/dedup.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/dedup.helpers.spec.ts
@@ -96,4 +96,17 @@ describe('deduplicateArticles', () => {
     expect(kept).toHaveLength(1);
     expect(removed).toHaveLength(1);
   });
+
+  it('preserves a16z-crypto articles when interleaved with other sources (no NaN sort)', () => {
+    const articles = [
+      stubArticle({ source: 'a16z-crypto', url: 'https://a16zcrypto.substack.com/p/agents', title: 'Agents are starting to operate real systems' }),
+      stubArticle({ source: 'carbon-pulse', url: 'https://carbon-pulse.com/methane/', title: 'Methane policy update' }),
+      stubArticle({ source: 'a16z-crypto', url: 'https://a16zcrypto.substack.com/p/stablecoins', title: 'Stablecoins are going local' }),
+      stubArticle({ source: 'esgnews', url: 'https://esgnews.com/eu-carbon/', title: 'EU carbon market analysis' }),
+    ];
+    const { kept, removed } = deduplicateArticles(articles);
+    expect(kept).toHaveLength(4);
+    expect(removed).toHaveLength(0);
+    expect(kept.map((a) => a.source).sort()).toEqual(['a16z-crypto', 'a16z-crypto', 'carbon-pulse', 'esgnews']);
+  });
 });

--- a/apps/news-digest/pipeline/src/helpers/__tests__/source.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/source.helpers.spec.ts
@@ -2,21 +2,23 @@ import { describe, it, expect } from 'vitest';
 import { sourceLabel, compactSourceLabel } from '../source.helpers.js';
 
 describe('sourceLabel', () => {
-  it.each<['carbon-pulse' | 'esgnews' | 'trellis', string]>([
+  it.each<['carbon-pulse' | 'esgnews' | 'trellis' | 'a16z-crypto', string]>([
     ['carbon-pulse', 'Carbon Pulse'],
     ['esgnews', 'ESG News'],
     ['trellis', 'Trellis'],
-  ])('maps %s to %s', (source, expected) => {
+    ['a16z-crypto', 'a16z crypto'],
+  ])('returns label for %s', (source, expected) => {
     expect(sourceLabel(source)).toBe(expected);
   });
 });
 
 describe('compactSourceLabel', () => {
-  it.each<['carbon-pulse' | 'esgnews' | 'trellis', string]>([
+  it.each<['carbon-pulse' | 'esgnews' | 'trellis' | 'a16z-crypto', string]>([
     ['carbon-pulse', 'CP'],
     ['esgnews', 'ESG'],
     ['trellis', 'Trellis'],
-  ])('maps %s to %s', (source, expected) => {
+    ['a16z-crypto', 'a16z'],
+  ])('returns compact label for %s', (source, expected) => {
     expect(compactSourceLabel(source)).toBe(expected);
   });
 });

--- a/apps/news-digest/pipeline/src/helpers/dedup.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/dedup.helpers.ts
@@ -22,6 +22,7 @@ const SOURCE_PRIORITY: Record<RawArticle['source'], number> = {
   'carbon-pulse': 0,
   trellis: 1,
   esgnews: 2,
+  'a16z-crypto': 3,
 };
 
 export function deduplicateArticles(articles: readonly RawArticle[]): DedupResult {

--- a/apps/news-digest/pipeline/src/helpers/source.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/source.helpers.ts
@@ -8,6 +8,8 @@ export function sourceLabel(source: RawArticle['source']): string {
       return 'ESG News';
     case 'trellis':
       return 'Trellis';
+    case 'a16z-crypto':
+      return 'a16z crypto';
     default: {
       const _exhaustive: never = source;
       return _exhaustive;
@@ -23,6 +25,8 @@ export function compactSourceLabel(source: RawArticle['source']): string {
       return 'ESG';
     case 'trellis':
       return 'Trellis';
+    case 'a16z-crypto':
+      return 'a16z';
     default: {
       const _exhaustive: never = source;
       return _exhaustive;

--- a/apps/news-digest/pipeline/src/orchestrator.ts
+++ b/apps/news-digest/pipeline/src/orchestrator.ts
@@ -5,12 +5,13 @@ import { buildArticleMarkdown, slugify } from './helpers/markdown.helpers.js';
 import { scrapeCarbonPulse } from './scraper/carbon-pulse.js';
 import { scrapeEsgNews } from './scraper/esg-news.js';
 import { scrapeTrellis } from './scraper/trellis.js';
+import { scrapeSubstack } from './scraper/substack.js';
 import { processArticle } from './ai/article-processor.js';
 import { postSlackDigest } from './distribution/slack.js';
 import { createNotionPage } from './distribution/notion.js';
 import { createGmailDraft } from './distribution/email.js';
 import { buildEmailHtml } from './distribution/email-template.helpers.js';
-import { THEMES } from './config.constants.js';
+import { THEMES, SUBSTACK_PUBLICATIONS } from './config.constants.js';
 import type { PipelineResult, ProcessedArticle, ProcessedState, RawArticle, Secrets } from './types.js';
 
 interface PipelineConfig {
@@ -262,12 +263,24 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     console.error(errors[errors.length - 1]);
   }
 
-  const allRaw = [...cpArticles, ...esgArticles, ...trellisArticles];
+  // Step 5b: Scrape Substack publications (always runs — no theme filter)
+  console.log('Step 5b: Scraping Substack publications...');
+  let substackArticles: RawArticle[] = [];
+  try {
+    substackArticles = await scrapeSubstack(SUBSTACK_PUBLICATIONS, processedUrls);
+    console.log(`Substack: ${substackArticles.length} articles from ${SUBSTACK_PUBLICATIONS.length} publication(s)`);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'unknown';
+    errors.push(`Substack scraping failed: ${msg}`);
+    console.error(errors[errors.length - 1]);
+  }
+
+  const allRaw = [...cpArticles, ...esgArticles, ...trellisArticles, ...substackArticles];
 
   if (allRaw.length === 0) {
     console.log('No articles scraped.');
     return {
-      steps: [], articlesScraped: 0, articlesBySource: { 'carbon-pulse': 0, esgnews: 0, trellis: 0 },
+      steps: [], articlesScraped: 0, articlesBySource: { 'carbon-pulse': 0, esgnews: 0, trellis: 0, 'a16z-crypto': 0 },
       deduped: 0, claudeProcessed: 0, claudeFallbacks: 0, notionCreated: 0, notionFailed: 0,
       emailDraftCreated: false, slackPosted: false, errors,
     };

--- a/apps/news-digest/pipeline/src/orchestrator.ts
+++ b/apps/news-digest/pipeline/src/orchestrator.ts
@@ -218,49 +218,45 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
   console.log(`Eligible themes: ${eligibleThemes.map((t) => t.name).join(', ')}`);
 
   if (eligibleThemes.length === 0) {
-    console.log('No eligible themes today.');
-    return {
-      steps: [], articlesScraped: 0, articlesBySource: {}, deduped: 0,
-      claudeProcessed: 0, claudeFallbacks: 0, notionCreated: 0, notionFailed: 0,
-      emailDraftCreated: false, slackPosted: false, errors: [],
-    };
+    console.log('No eligible themes today. Skipping theme-driven sources, continuing with Substack.');
   }
 
-  // Step 3: Scrape Carbon Pulse
-  console.log('Step 3: Scraping Carbon Pulse...');
+  // Steps 3-5: Theme-driven sources (gated)
   let cpArticles: RawArticle[] = [];
-  try {
-    cpArticles = await scrapeCarbonPulse(eligibleThemes, processedUrls, config.secrets.carbonPulse, config.secrets.proxy);
-    console.log(`Carbon Pulse: ${cpArticles.length} articles`);
-  } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : 'unknown';
-    errors.push(`Carbon Pulse scraping failed: ${msg}`);
-    console.error(errors[errors.length - 1]);
-  }
-
-  // Step 4: Scrape ESG News
-  console.log('Step 4: Scraping ESG News...');
   let esgArticles: RawArticle[] = [];
-  try {
-    const cpTitles = cpArticles.map((a) => a.title);
-    esgArticles = await scrapeEsgNews(eligibleThemes, processedUrls, cpTitles);
-    console.log(`ESG News: ${esgArticles.length} articles`);
-  } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : 'unknown';
-    errors.push(`ESG News scraping failed: ${msg}`);
-    console.error(errors[errors.length - 1]);
-  }
-
-  // Step 5: Scrape Trellis
-  console.log('Step 5: Scraping Trellis...');
   let trellisArticles: RawArticle[] = [];
-  try {
-    trellisArticles = await scrapeTrellis(eligibleThemes, processedUrls, config.secrets.anthropicApiKey);
-    console.log(`Trellis: ${trellisArticles.length} articles`);
-  } catch (error: unknown) {
-    const msg = error instanceof Error ? error.message : 'unknown';
-    errors.push(`Trellis scraping failed: ${msg}`);
-    console.error(errors[errors.length - 1]);
+
+  if (eligibleThemes.length > 0) {
+    console.log('Step 3: Scraping Carbon Pulse...');
+    try {
+      cpArticles = await scrapeCarbonPulse(eligibleThemes, processedUrls, config.secrets.carbonPulse, config.secrets.proxy);
+      console.log(`Carbon Pulse: ${cpArticles.length} articles`);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'unknown';
+      errors.push(`Carbon Pulse scraping failed: ${msg}`);
+      console.error(errors[errors.length - 1]);
+    }
+
+    console.log('Step 4: Scraping ESG News...');
+    try {
+      const cpTitles = cpArticles.map((a) => a.title);
+      esgArticles = await scrapeEsgNews(eligibleThemes, processedUrls, cpTitles);
+      console.log(`ESG News: ${esgArticles.length} articles`);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'unknown';
+      errors.push(`ESG News scraping failed: ${msg}`);
+      console.error(errors[errors.length - 1]);
+    }
+
+    console.log('Step 5: Scraping Trellis...');
+    try {
+      trellisArticles = await scrapeTrellis(eligibleThemes, processedUrls, config.secrets.anthropicApiKey);
+      console.log(`Trellis: ${trellisArticles.length} articles`);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'unknown';
+      errors.push(`Trellis scraping failed: ${msg}`);
+      console.error(errors[errors.length - 1]);
+    }
   }
 
   // Step 5b: Scrape Substack publications (always runs — no theme filter)

--- a/apps/news-digest/pipeline/src/scraper/__tests__/fixtures/substack-feed-malformed.xml
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/fixtures/substack-feed-malformed.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss><channel><item><title>Broken</title><link>https://x.y/p/1

--- a/apps/news-digest/pipeline/src/scraper/__tests__/fixtures/substack-feed-valid.xml
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/fixtures/substack-feed-valid.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+  <channel>
+    <title>Sample Substack</title>
+    <link>https://sample.substack.com</link>
+    <description>Sample feed for tests</description>
+    <item>
+      <title>First post</title>
+      <link>https://sample.substack.com/p/first-post</link>
+      <pubDate>Sat, 25 Apr 2026 10:00:00 GMT</pubDate>
+      <description>Short summary one.</description>
+      <content:encoded><![CDATA[<p>Hello <strong>world</strong>.</p><p>Second paragraph with <a href="https://x.com">link</a>.</p>]]></content:encoded>
+    </item>
+    <item>
+      <title>Second post — already seen</title>
+      <link>https://sample.substack.com/p/second-post</link>
+      <pubDate>Sat, 18 Apr 2026 10:00:00 GMT</pubDate>
+      <content:encoded><![CDATA[<p>Body of the second post.</p>]]></content:encoded>
+    </item>
+    <item>
+      <title>Third post — description-only fallback</title>
+      <link>https://sample.substack.com/p/third-post</link>
+      <pubDate>Sat, 11 Apr 2026 10:00:00 GMT</pubDate>
+      <description>Only description, no encoded content here.</description>
+    </item>
+  </channel>
+</rss>

--- a/apps/news-digest/pipeline/src/scraper/__tests__/substack.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/substack.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { scrapeSubstack, stripHtml } from '../substack.js';
+import type { SubstackPublication } from '../../types.js';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const VALID_XML = readFileSync(join(FIXTURES, 'substack-feed-valid.xml'), 'utf-8');
+
+const PUBLICATION: SubstackPublication = {
+  name: 'Sample Substack',
+  source: 'a16z-crypto',
+  feedUrl: 'https://sample.substack.com/feed',
+};
+
+function mockFetchOk(body: string): void {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => body,
+  } as Response));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-29T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('stripHtml', () => {
+  it('strips tags and decodes common entities', () => {
+    const html = '<p>Hello &amp; <strong>world</strong>.</p><p>Second.</p>';
+    expect(stripHtml(html)).toBe('Hello & world.\n\nSecond.');
+  });
+
+  it('preserves paragraph breaks via double newline', () => {
+    expect(stripHtml('<p>A</p><p>B</p>')).toBe('A\n\nB');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripHtml('')).toBe('');
+  });
+});
+
+describe('scrapeSubstack — happy path', () => {
+  it('returns RawArticle[] for new items in the feed', async () => {
+    mockFetchOk(VALID_XML);
+
+    const articles = await scrapeSubstack([PUBLICATION], new Set());
+
+    expect(articles).toHaveLength(3);
+    expect(articles[0]).toMatchObject({
+      source: 'a16z-crypto',
+      url: 'https://sample.substack.com/p/first-post',
+      title: 'First post',
+      date: '2026-04-25',
+      author: 'Sample Substack',
+      mainTheme: 'Industry Intelligence',
+      categories: '',
+      location: '',
+    });
+    expect(articles[0]!.fullContent).toContain('Hello world');
+    expect(articles[0]!.fullContent).toContain('Second paragraph with link');
+  });
+});
+
+describe('scrapeSubstack — dedup', () => {
+  it('skips items whose link is already in processedUrls', async () => {
+    mockFetchOk(VALID_XML);
+    const seen = new Set(['https://sample.substack.com/p/second-post']);
+
+    const articles = await scrapeSubstack([PUBLICATION], seen);
+
+    expect(articles).toHaveLength(2);
+    expect(articles.map((a) => a.url)).not.toContain('https://sample.substack.com/p/second-post');
+  });
+});
+
+describe('scrapeSubstack — content fallback', () => {
+  it('uses description when content:encoded is missing', async () => {
+    mockFetchOk(VALID_XML);
+
+    const articles = await scrapeSubstack([PUBLICATION], new Set());
+
+    const third = articles.find((a) => a.url.endsWith('/third-post'))!;
+    expect(third.fullContent).toBe('Only description, no encoded content here.');
+  });
+
+  it('skips item with neither content:encoded nor description', async () => {
+    const xml = `<?xml version="1.0"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+  <channel>
+    <item>
+      <title>Empty</title>
+      <link>https://sample.substack.com/p/empty</link>
+      <pubDate>Sat, 25 Apr 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+    mockFetchOk(xml);
+
+    const articles = await scrapeSubstack([PUBLICATION], new Set());
+
+    expect(articles).toHaveLength(0);
+  });
+});
+
+describe('scrapeSubstack — pubDate handling', () => {
+  it('falls back to current timestamp when pubDate is missing', async () => {
+    const xml = `<?xml version="1.0"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+  <channel>
+    <item>
+      <title>No date</title>
+      <link>https://sample.substack.com/p/no-date</link>
+      <content:encoded><![CDATA[<p>Body.</p>]]></content:encoded>
+    </item>
+  </channel>
+</rss>`;
+    mockFetchOk(xml);
+
+    const articles = await scrapeSubstack([PUBLICATION], new Set());
+
+    expect(articles).toHaveLength(1);
+    expect(articles[0]!.date).toBe('2026-04-29');
+  });
+
+  it('skips items older than 90-day retention cutoff', async () => {
+    const xml = `<?xml version="1.0"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+  <channel>
+    <item>
+      <title>Old</title>
+      <link>https://sample.substack.com/p/old</link>
+      <pubDate>Mon, 01 Jan 2025 10:00:00 GMT</pubDate>
+      <content:encoded><![CDATA[<p>Body.</p>]]></content:encoded>
+    </item>
+    <item>
+      <title>Fresh</title>
+      <link>https://sample.substack.com/p/fresh</link>
+      <pubDate>Sat, 25 Apr 2026 10:00:00 GMT</pubDate>
+      <content:encoded><![CDATA[<p>Body.</p>]]></content:encoded>
+    </item>
+  </channel>
+</rss>`;
+    mockFetchOk(xml);
+
+    const articles = await scrapeSubstack([PUBLICATION], new Set());
+
+    expect(articles).toHaveLength(1);
+    expect(articles[0]!.url).toBe('https://sample.substack.com/p/fresh');
+  });
+});
+
+describe('scrapeSubstack — multiple publications', () => {
+  const PUB_A: SubstackPublication = {
+    name: 'Pub A',
+    source: 'a16z-crypto',
+    feedUrl: 'https://a.substack.com/feed',
+  };
+  const PUB_B: SubstackPublication = {
+    name: 'Pub B',
+    source: 'a16z-crypto',
+    feedUrl: 'https://b.substack.com/feed',
+  };
+
+  it('concatenates results across publications', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (url === PUB_A.feedUrl) {
+        return Promise.resolve({ ok: true, status: 200, text: async () => VALID_XML } as Response);
+      }
+      return Promise.resolve({ ok: true, status: 200, text: async () => VALID_XML } as Response);
+    }));
+
+    const articles = await scrapeSubstack([PUB_A, PUB_B], new Set());
+
+    expect(articles).toHaveLength(6);
+  });
+
+  it('isolates failure: one publication fails, the other succeeds', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (url === PUB_A.feedUrl) {
+        return Promise.reject(new Error('network error'));
+      }
+      return Promise.resolve({ ok: true, status: 200, text: async () => VALID_XML } as Response);
+    }));
+
+    const articles = await scrapeSubstack([PUB_A, PUB_B], new Set());
+
+    expect(articles).toHaveLength(3);
+    expect(articles.every((a) => a.url.startsWith('https://sample.substack.com'))).toBe(true);
+  });
+
+  it('isolates failure: one publication has malformed XML, the other succeeds', async () => {
+    const malformed = readFileSync(join(FIXTURES, 'substack-feed-malformed.xml'), 'utf-8');
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (url === PUB_A.feedUrl) {
+        return Promise.resolve({ ok: true, status: 200, text: async () => malformed } as Response);
+      }
+      return Promise.resolve({ ok: true, status: 200, text: async () => VALID_XML } as Response);
+    }));
+
+    const articles = await scrapeSubstack([PUB_A, PUB_B], new Set());
+
+    expect(articles).toHaveLength(3);
+  });
+
+  it('returns [] when feed has no items', async () => {
+    const empty = `<?xml version="1.0"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+  <channel><title>Empty</title></channel>
+</rss>`;
+    mockFetchOk(empty);
+
+    const articles = await scrapeSubstack([PUBLICATION], new Set());
+
+    expect(articles).toHaveLength(0);
+  });
+});

--- a/apps/news-digest/pipeline/src/scraper/__tests__/substack.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/substack.spec.ts
@@ -53,6 +53,11 @@ describe('stripHtml', () => {
   it('decodes hex numeric HTML entities', () => {
     expect(stripHtml('Em dash &#x2014; here')).toBe('Em dash — here');
   });
+
+  it('preserves out-of-range numeric entities verbatim instead of throwing', () => {
+    expect(stripHtml('Decimal overflow &#9999999999; survives')).toBe('Decimal overflow &#9999999999; survives');
+    expect(stripHtml('Hex overflow &#x110000; survives')).toBe('Hex overflow &#x110000; survives');
+  });
 });
 
 describe('scrapeSubstack — happy path', () => {

--- a/apps/news-digest/pipeline/src/scraper/__tests__/substack.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/substack.spec.ts
@@ -45,6 +45,14 @@ describe('stripHtml', () => {
   it('returns empty string for empty input', () => {
     expect(stripHtml('')).toBe('');
   });
+
+  it('decodes decimal numeric HTML entities', () => {
+    expect(stripHtml('Smart quotes &#8220;hello&#8221; and apostrophe&#8217;s')).toBe('Smart quotes “hello” and apostrophe’s');
+  });
+
+  it('decodes hex numeric HTML entities', () => {
+    expect(stripHtml('Em dash &#x2014; here')).toBe('Em dash — here');
+  });
 });
 
 describe('scrapeSubstack — happy path', () => {

--- a/apps/news-digest/pipeline/src/scraper/substack.ts
+++ b/apps/news-digest/pipeline/src/scraper/substack.ts
@@ -29,11 +29,15 @@ export function stripHtml(html: string): string {
     .replace(/&#x27;/g, "'")
     .replace(/&#(\d+);/g, (match, dec: string) => {
       const code = Number.parseInt(dec, 10);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+      return Number.isInteger(code) && code >= 0 && code <= 0x10ffff
+        ? String.fromCodePoint(code)
+        : match;
     })
     .replace(/&#x([0-9a-f]+);/gi, (match, hex: string) => {
       const code = Number.parseInt(hex, 16);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+      return Number.isInteger(code) && code >= 0 && code <= 0x10ffff
+        ? String.fromCodePoint(code)
+        : match;
     })
     .replace(/[ \t]+/g, ' ')
     .replace(/\n[ \t]+/g, '\n')

--- a/apps/news-digest/pipeline/src/scraper/substack.ts
+++ b/apps/news-digest/pipeline/src/scraper/substack.ts
@@ -2,6 +2,7 @@ import { XMLParser } from 'fast-xml-parser';
 import type { RawArticle, SubstackPublication } from '../types.js';
 
 const RETENTION_DAYS = 90;
+const FETCH_TIMEOUT_MS = 10_000;
 
 interface RssItem {
   readonly title?: string;
@@ -26,6 +27,14 @@ export function stripHtml(html: string): string {
     .replace(/&#039;/g, "'")
     .replace(/&apos;/g, "'")
     .replace(/&#x27;/g, "'")
+    .replace(/&#(\d+);/g, (match, dec: string) => {
+      const code = Number.parseInt(dec, 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (match, hex: string) => {
+      const code = Number.parseInt(hex, 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    })
     .replace(/[ \t]+/g, ' ')
     .replace(/\n[ \t]+/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
@@ -44,9 +53,11 @@ async function scrapeOnePublication(
   processedUrls: ReadonlySet<string>,
   cutoffMs: number,
 ): Promise<readonly RawArticle[]> {
-  const response = await fetch(publication.feedUrl);
+  const response = await fetch(publication.feedUrl, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
+    throw new Error(`[${publication.name}] HTTP ${response.status} for ${publication.feedUrl}`);
   }
   const xml = await response.text();
   const parser = new XMLParser({ ignoreAttributes: true });

--- a/apps/news-digest/pipeline/src/scraper/substack.ts
+++ b/apps/news-digest/pipeline/src/scraper/substack.ts
@@ -1,0 +1,114 @@
+import { XMLParser } from 'fast-xml-parser';
+import type { RawArticle, SubstackPublication } from '../types.js';
+
+const RETENTION_DAYS = 90;
+
+interface RssItem {
+  readonly title?: string;
+  readonly link?: string;
+  readonly pubDate?: string;
+  readonly description?: string;
+  readonly 'content:encoded'?: string;
+}
+
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>\s*<p[^>]*>/gi, '\n\n')
+    .replace(/<\/p>/gi, '')
+    .replace(/<p[^>]*>/gi, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function parsePubDate(raw: string | undefined): string {
+  if (!raw) return new Date().toISOString();
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return new Date().toISOString();
+  return parsed.toISOString();
+}
+
+async function scrapeOnePublication(
+  publication: SubstackPublication,
+  processedUrls: ReadonlySet<string>,
+  cutoffMs: number,
+): Promise<readonly RawArticle[]> {
+  const response = await fetch(publication.feedUrl);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const xml = await response.text();
+  const parser = new XMLParser({ ignoreAttributes: true });
+  const parsed = parser.parse(xml) as { rss?: { channel?: { item?: RssItem | RssItem[] } } };
+  if (typeof parsed !== 'object' || parsed === null || typeof parsed.rss !== 'object' || parsed.rss === null) {
+    throw new Error('Invalid RSS: not an object');
+  }
+  const channel = parsed.rss.channel;
+  if (!channel || typeof channel !== 'object') {
+    throw new Error('Invalid RSS: missing channel');
+  }
+  const itemsRaw = channel.item;
+  const items: readonly RssItem[] = Array.isArray(itemsRaw) ? itemsRaw : itemsRaw ? [itemsRaw] : [];
+
+  const articles: RawArticle[] = [];
+  for (const item of items) {
+    const link = item.link;
+    if (!link || processedUrls.has(link)) continue;
+
+    const publishedAt = parsePubDate(item.pubDate);
+    if (new Date(publishedAt).getTime() < cutoffMs) continue;
+
+    const html = item['content:encoded'] ?? item.description ?? '';
+    if (!html) continue;
+    const fullContent = stripHtml(html);
+    if (!fullContent) continue;
+
+    articles.push({
+      source: publication.source,
+      url: link,
+      title: item.title ?? '',
+      date: publishedAt.slice(0, 10),
+      author: publication.name,
+      mainTheme: 'Industry Intelligence',
+      categories: '',
+      location: '',
+      fullContent,
+    });
+  }
+  return articles;
+}
+
+export async function scrapeSubstack(
+  publications: readonly SubstackPublication[],
+  processedUrls: ReadonlySet<string>,
+): Promise<RawArticle[]> {
+  const cutoffMs = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const results = await Promise.allSettled(
+    publications.map((pub) => scrapeOnePublication(pub, processedUrls, cutoffMs)),
+  );
+
+  const articles: RawArticle[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]!;
+    const pub = publications[i]!;
+    if (result.status === 'fulfilled') {
+      articles.push(...result.value);
+      console.log(`[Substack:${pub.name}] ${result.value.length} articles`);
+    } else {
+      const msg = result.reason instanceof Error ? result.reason.message : 'unknown';
+      console.error(`[Substack:${pub.name}] failed: ${msg}`);
+    }
+  }
+  return articles;
+}

--- a/apps/news-digest/pipeline/src/state/__tests__/s3-store.spec.ts
+++ b/apps/news-digest/pipeline/src/state/__tests__/s3-store.spec.ts
@@ -84,6 +84,36 @@ describe('S3Store', () => {
     expect(state.processedArticles[0]?.source).toBe('trellis');
   });
 
+  it('loadState accepts a16z-crypto-sourced articles in existing state', async () => {
+    const existingState = {
+      processedArticles: [{
+        source: 'a16z-crypto',
+        url: 'https://a16zcrypto.substack.com/p/agents',
+        title: 'Agents are starting to operate real systems',
+        date: '2026-04-18',
+        author: 'a16z crypto',
+        mainTheme: 'Industry Intelligence',
+        categories: '',
+        location: '',
+        summary: 'Summary',
+        keyPoints: [],
+        segment: 'Big Tech',
+        fullContent: '',
+        markdownFile: 'agents.md',
+        notionPageId: null,
+        processedAt: '2026-04-18T10:00:00Z',
+        status: 'markdown-only',
+      }],
+      themeLastProcessed: {},
+    };
+    mockSend.mockResolvedValueOnce({
+      Body: { transformToString: () => Promise.resolve(JSON.stringify(existingState)) },
+    });
+    const state = await store.loadState('state.json');
+    expect(state.processedArticles).toHaveLength(1);
+    expect(state.processedArticles[0]?.source).toBe('a16z-crypto');
+  });
+
   it('saveState uploads JSON to S3', async () => {
     mockSend.mockResolvedValueOnce({});
     const state = { processedArticles: [], themeLastProcessed: {}, slackPostedAt: '' };

--- a/apps/news-digest/pipeline/src/types.ts
+++ b/apps/news-digest/pipeline/src/types.ts
@@ -1,5 +1,5 @@
 export interface RawArticle {
-  readonly source: 'carbon-pulse' | 'esgnews' | 'trellis';
+  readonly source: 'carbon-pulse' | 'esgnews' | 'trellis' | 'a16z-crypto';
   readonly url: string;
   readonly title: string;
   readonly date: string;
@@ -11,7 +11,7 @@ export interface RawArticle {
 }
 
 export interface ProcessedArticle {
-  readonly source: 'carbon-pulse' | 'esgnews' | 'trellis';
+  readonly source: 'carbon-pulse' | 'esgnews' | 'trellis' | 'a16z-crypto';
   readonly url: string;
   readonly title: string;
   readonly date: string;
@@ -100,4 +100,10 @@ export interface Secrets {
     readonly clientSecret: string;
     readonly refreshToken: string;
   };
+}
+
+export interface SubstackPublication {
+  readonly name: string;
+  readonly source: RawArticle['source'];
+  readonly feedUrl: string;
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@aws-sdk/client-secrets-manager": "3.1018.0",
     "@mui/lab": "7.0.1-beta.18",
     "@mui/material": "7.3.4",
+    "fast-xml-parser": "5.7.2",
     "next": "15.5.4",
     "nx-release": "3.3.0",
     "pino": "10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@mui/material':
         specifier: 7.3.4
         version: 7.3.4(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      fast-xml-parser:
+        specifier: 5.7.2
+        version: 5.7.2
       next:
         specifier: 15.5.4
         version: 15.5.4(@babel/core@7.27.4)(@opentelemetry/api@1.7.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2263,6 +2266,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5649,12 +5655,19 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
   fast-xml-parser@4.2.5:
     resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
     hasBin: true
 
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastest-stable-stringify@2.0.2:
@@ -8016,6 +8029,10 @@ packages:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -9023,6 +9040,9 @@ packages:
 
   strnum@2.2.2:
     resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   strtok3@7.1.1:
     resolution: {integrity: sha512-mKX8HA/cdBqMKUr0MMZAFssCkIGoZeSCMXgnt79yKxNFguMLVFgRe6wB+fsL0NmoHDbeyZXczy7vEPSoo3rkzg==}
@@ -12938,6 +12958,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.4':
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -17186,6 +17208,10 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.0
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
   fast-xml-parser@4.2.5:
     dependencies:
       strnum: 1.1.2
@@ -17195,6 +17221,13 @@ snapshots:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
       strnum: 2.2.2
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastest-stable-stringify@2.0.2: {}
 
@@ -19902,6 +19935,8 @@ snapshots:
 
   path-expression-matcher@1.2.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@2.0.1: {}
@@ -21201,6 +21236,8 @@ snapshots:
   strnum@1.1.2: {}
 
   strnum@2.2.2: {}
+
+  strnum@2.2.3: {}
 
   strtok3@7.1.1:
     dependencies:


### PR DESCRIPTION
### Summary

Adds a generic Substack RSS scraper to the news-digest pipeline and registers `a16z crypto` as the first publication. Substack posts now flow through the same dedup → Claude AI → S3 → Notion + Gmail digest + Slack pipeline as Carbon Pulse / ESG News / Trellis content. Adding more Substack newsletters in the future is one line of config.

### Details

**Why this exists:** the CEO forwarded the a16z crypto newsletter on 2026-04-19 asking that we track it alongside our existing intelligence sources. Although it arrives via email, every Substack publication exposes a public RSS feed at `https://<publication>.substack.com/feed` with the full post body — so no email-ingestion infrastructure is needed.

**What changed:**

- `apps/news-digest/pipeline/src/scraper/substack.ts` — new generic scraper. For each `SubstackPublication` in the config, it fetches the feed, parses with `fast-xml-parser`, applies a 90-day retention cutoff (matching `STATE_RETENTION_DAYS`), skips items already in `processedUrls`, falls back from `content:encoded` → `description` → skip, strips HTML to clean text, and returns `RawArticle[]`. Per-publication failures are isolated via `Promise.allSettled`.
- `apps/news-digest/pipeline/src/scraper/__tests__/substack.spec.ts` — 13 Vitest tests covering happy path, dedup, content fallback, missing/old `pubDate`, multi-publication, fetch failure, malformed XML, empty feed.
- `apps/news-digest/pipeline/src/types.ts` — extends `RawArticle.source` and `ProcessedArticle.source` unions with `'a16z-crypto'`; adds `SubstackPublication` interface.
- `apps/news-digest/pipeline/src/helpers/source.helpers.ts` — adds the `'a16z-crypto'` case in both `sourceLabel` (returns `'a16z crypto'`) and `compactSourceLabel` (returns `'a16z'`). The exhaustive `never` switch enforced this.
- `apps/news-digest/pipeline/src/config.constants.ts` — new `SUBSTACK_PUBLICATIONS` constant with the a16z entry.
- `apps/news-digest/pipeline/src/orchestrator.ts` — new "Step 5b" calls `scrapeSubstack` unconditionally (no theme filter), appends to `allRaw`, and updates the zero-articles `articlesBySource` fallback.
- `package.json` — adds `fast-xml-parser@5.7.2`.

**Smoke-tested against the live feed:** the scraper returned 20 articles spanning 2026-02-14 through 2026-04-25, with content sizes ranging from ~5K to ~31K characters, correct dates, and the right source/author/theme metadata.

**Notion behavior:** Substack articles use `mainTheme: 'Industry Intelligence'`, which is **not** in `NOTION_VALID_THEMES`. As a result, the `Main Theme` property won't be set on those Notion pages — Title, Source, Date, Segment (from Claude), and content all populate normally. To get the tag rendered, add `'Industry Intelligence'` as a select option in the Notion DB and to `NOTION_VALID_THEMES` in a follow-up.

**Known minor gap:** `stripHtml` decodes named HTML entities (`&amp;`, `&nbsp;`, etc.) but leaves numeric ones (`&#8217;`, `&#8220;`, `&#8212;`). The Claude summarizer downstream is likely to normalize them, but a single regex pass could clean source content if needed later.

### Testing

```bash
# All pipeline tests (109 across 14 files)
cd apps/news-digest/pipeline && npx vitest run --no-coverage

# Just the substack suite (13 tests)
cd apps/news-digest/pipeline && npx vitest run --no-coverage src/scraper/__tests__/substack.spec.ts

# Type-check + bundle
pnpm nx run news-digest-pipeline:build

# Live feed smoke (ad-hoc, not committed)
cd apps/news-digest/pipeline && npx tsx -e "
import { scrapeSubstack } from './src/scraper/substack.js';
import { SUBSTACK_PUBLICATIONS } from './src/config.constants.js';
scrapeSubstack(SUBSTACK_PUBLICATIONS, new Set()).then(a => console.log(a.length, 'articles'));
"
```

After deploy, verify in CloudWatch that the next pipeline run logs `Substack: N articles from 1 publication(s)` and that `articlesBySource` contains an `'a16z-crypto'` entry.

### Related links

- Source-of-truth spec: `docs/superpowers/specs/2026-04-29-substack-newsletter-tracking-design.md` (local-only — `docs/superpowers/` is gitignored).
- Implementation plan: `docs/superpowers/plans/2026-04-29-substack-newsletter-tracking.md` (local-only).
- Originating email: Ian McKee, 2026-04-19.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new always-on network scraper and XML parsing dependency, which could affect pipeline reliability and article volume/ordering if feeds are malformed or slow despite added timeouts and tests.
> 
> **Overview**
> Adds Substack RSS ingestion to the news-digest pipeline and registers `a16z crypto` as the first publication, flowing its posts through the existing dedup → AI processing → S3/Notion/Gmail/Slack workflow.
> 
> The pipeline now scrapes Substack feeds (with timeout, per-publication failure isolation, 90-day retention cutoff, and HTML-to-text cleanup), extends article/source types and labels to include `a16z-crypto`, updates dedup source priority to avoid `NaN` sorting, and relaxes state schema/tests to accept the new source. A new dependency (`fast-xml-parser`) and a focused Substack scraper test suite/fixtures are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de95b27d43e0b7da9d1060621405b52c2eb0aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->