### PR TITLE
Fix broken news-digest articles: sanitize scraped content + add source URL

### DIFF
--- a/apps/news-digest/pipeline/src/ai/__tests__/article-processor.spec.ts
+++ b/apps/news-digest/pipeline/src/ai/__tests__/article-processor.spec.ts
@@ -28,6 +28,21 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('keyPoints');
     expect(prompt).toContain('segment');
   });
+
+  it('feeds Claude sanitized content so chrome cannot skew summary/segment (regression: 2026-05-18)', () => {
+    const prompt = buildPrompt(
+      stubRawArticle({
+        fullContent:
+          'Share on Facebook\n' +
+          '<img loading="lazy" src="https://esgnews.com/x.webp" srcset="x 780w" />\n' +
+          'Indonesia plans to rehabilitate 12 million hectares of degraded land.',
+      }),
+    );
+    expect(prompt).not.toContain('<img');
+    expect(prompt).not.toContain('srcset');
+    expect(prompt).not.toContain('Share on Facebook');
+    expect(prompt).toContain('Indonesia plans to rehabilitate 12 million hectares of degraded land.');
+  });
 });
 
 describe('processArticle', () => {
@@ -61,5 +76,20 @@ describe('processArticle', () => {
     expect(result.summary).toContain('EU carbon prices rose 15%');
     expect(result.keyPoints).toEqual([]);
     expect(result.segment).toBe('');
+  });
+
+  it('produces a clean fallback summary, not scraped chrome (regression: 2026-05-18)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('API Error'));
+    const article = stubRawArticle({
+      fullContent:
+        'Share on Facebook\nShare on LinkedIn\n' +
+        '<img loading="lazy" src="https://esgnews.com/x.webp" srcset="x 780w" />\n' +
+        'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.',
+    });
+    const result = await processArticle(article, 'test-api-key');
+    expect(result.isFallback).toBe(true);
+    expect(result.summary).not.toContain('<img');
+    expect(result.summary).not.toContain('Share on Facebook');
+    expect(result.summary).toContain('New Zealand plans to amend the Climate Change Response Act 2002');
   });
 });

--- a/apps/news-digest/pipeline/src/ai/article-processor.ts
+++ b/apps/news-digest/pipeline/src/ai/article-processor.ts
@@ -1,4 +1,5 @@
 import { SEGMENTS } from '../config.constants.js';
+import { sanitizeArticleText } from '../helpers/content.helpers.js';
 import type { RawArticle } from '../types.js';
 
 const CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
@@ -14,7 +15,7 @@ export interface ClaudeResult {
 }
 
 export function buildPrompt(article: RawArticle): string {
-  const truncatedContent = article.fullContent.slice(0, MAX_CONTENT_FOR_PROMPT);
+  const truncatedContent = sanitizeArticleText(article.fullContent).slice(0, MAX_CONTENT_FOR_PROMPT);
   const segmentList = SEGMENTS.join(', ');
 
   return `Analyze this news article and return a JSON object with exactly these fields:
@@ -35,7 +36,7 @@ Return ONLY valid JSON, no markdown fences, no explanation.`;
 }
 
 function parseFallback(article: RawArticle): ClaudeResult {
-  const summary = article.fullContent.slice(0, MAX_FALLBACK_SUMMARY).trimEnd();
+  const summary = sanitizeArticleText(article.fullContent).slice(0, MAX_FALLBACK_SUMMARY).trimEnd();
   return { summary: summary || article.title, keyPoints: [], segment: '', isFallback: true };
 }
 

--- a/apps/news-digest/pipeline/src/distribution/__tests__/notion.spec.ts
+++ b/apps/news-digest/pipeline/src/distribution/__tests__/notion.spec.ts
@@ -31,9 +31,40 @@ describe('createNotionPage', () => {
     expect(body.properties['Main Theme']).toBeUndefined();
   });
 
+  it('stores the source article URL in the "Source URL" property', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 'page-u' }) });
+    await createNotionPage(
+      stubProcessedArticle({ url: 'https://esgnews.com/some-article/' }),
+      'db-id',
+      'token',
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.properties['Source URL']).toEqual({ url: 'https://esgnews.com/some-article/' });
+  });
+
   it('returns failure on API error', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 400, text: () => Promise.resolve('Bad Request') });
     const result = await createNotionPage(stubProcessedArticle(), 'db-id', 'token');
     expect(result.success).toBe(false);
+  });
+
+  it('sanitizes scraped chrome out of the page body (regression: 2026-05-18 broken articles)', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 'page-x' }) });
+    const dirty =
+      'Share on Facebook\nShare on LinkedIn\n' +
+      '<img loading="lazy" src="https://esgnews.com/x.webp" srcset="https://esgnews.com/x.webp 780w" />\n' +
+      'New Zealand plans to amend the Climate Change Response Act 2002.\n' +
+      'Subscribe & Follow for Daily ESG Insights\n' +
+      'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran journalists.';
+    await createNotionPage(stubProcessedArticle({ fullContent: dirty }), 'db-id', 'token');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    const rendered = JSON.stringify(body.children);
+    expect(rendered).not.toContain('<img');
+    expect(rendered).not.toContain('srcset');
+    expect(rendered).not.toContain('Share on Facebook');
+    expect(rendered).not.toContain('Subscribe & Follow');
+    expect(rendered).not.toContain('Editorial Team is comprised of');
+    expect(rendered).toContain('New Zealand plans to amend the Climate Change Response Act 2002.');
   });
 });

--- a/apps/news-digest/pipeline/src/distribution/notion.ts
+++ b/apps/news-digest/pipeline/src/distribution/notion.ts
@@ -1,6 +1,7 @@
 import type { ProcessedArticle } from '../types.js';
 import { NOTION_VALID_THEMES } from '../config.constants.js';
 import { sourceLabel } from '../helpers/source.helpers.js';
+import { sanitizeArticleText } from '../helpers/content.helpers.js';
 
 interface NotionResult {
   readonly success: boolean;
@@ -28,6 +29,9 @@ function buildPageProperties(article: ProcessedArticle): Record<string, unknown>
     },
     Date: {
       date: { start: article.date },
+    },
+    'Source URL': {
+      url: article.url,
     },
   };
 
@@ -67,7 +71,14 @@ function buildPageContent(article: ProcessedArticle): unknown[] {
   }
 
   children.push(...chunkText(`Summary:\n${article.summary}`));
-  children.push(...chunkText(article.fullContent));
+
+  // Last-barrier sanitization: strip any scraped page chrome (nav, share
+  // buttons, <noscript> <img> markup, author bios, newsletter signups) that
+  // slipped through a scraper before it is written verbatim into Notion.
+  const cleanContent = sanitizeArticleText(article.fullContent);
+  if (cleanContent) {
+    children.push(...chunkText(cleanContent));
+  }
 
   return children;
 }

--- a/apps/news-digest/pipeline/src/helpers/__tests__/content.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/content.helpers.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeArticleText } from '../content.helpers.js';
+
+// These fixtures are trimmed copies of the *actual* broken content the
+// pipeline wrote to Notion on 2026-05-18 (ESG News article body + Carbon
+// Pulse "Daily News Ticker" listing page). They lock in the regression.
+
+describe('sanitizeArticleText', () => {
+  it('strips literal <img> markup leaked from <noscript> lazy-load wrappers', () => {
+    const raw =
+      'Indonesia plans to rehabilitate 12 million hectares of degraded land.\n' +
+      '<img loading="lazy" width="780" height="439" ' +
+      'src="https://esgnews.com/wp-content/uploads/2026/05/Indonesia.webp" ' +
+      'class="tw-absolute tw-top-0" alt="Indonesia" decoding="async" ' +
+      'srcset="https://esgnews.com/x.webp 780w" sizes="(max-width: 780px) 100vw, 780px" />\n' +
+      'Forestry officials announced the commitment.';
+
+    const cleaned = sanitizeArticleText(raw);
+
+    expect(cleaned).not.toContain('<img');
+    expect(cleaned).not.toContain('srcset');
+    expect(cleaned).not.toContain('.webp');
+    expect(cleaned).toContain('Indonesia plans to rehabilitate 12 million hectares of degraded land.');
+    expect(cleaned).toContain('Forestry officials announced the commitment.');
+  });
+
+  it('strips stray <br> and other residual HTML tags', () => {
+    const raw = 'First sentence.<br><br>Second sentence.<br /> <p>Third.</p>';
+    const cleaned = sanitizeArticleText(raw);
+    expect(cleaned).not.toMatch(/<[^>]+>/);
+    expect(cleaned).toContain('First sentence.');
+    expect(cleaned).toContain('Second sentence.');
+    expect(cleaned).toContain('Third.');
+  });
+
+  it('collapses CSS-layout whitespace/newline runs into clean paragraphs', () => {
+    const raw =
+      '      \n        \n          \n            Real article paragraph one.\n\n\n\n\n' +
+      '          \n        \n      Real article paragraph two.\n\n\n\n';
+    const cleaned = sanitizeArticleText(raw);
+    expect(cleaned).not.toMatch(/^\s{2,}/m);
+    expect(cleaned).not.toMatch(/\n{3,}/);
+    expect(cleaned).toContain('Real article paragraph one.');
+    expect(cleaned).toContain('Real article paragraph two.');
+  });
+
+  it('removes social share boilerplate (ESG News chrome)', () => {
+    const raw =
+      'Share:\nShare on Facebook\nShare on Twitter\nShare on LinkedIn\n' +
+      'New Zealand plans to amend the Climate Change Response Act 2002.';
+    const cleaned = sanitizeArticleText(raw);
+    expect(cleaned).not.toMatch(/Share on (Facebook|Twitter|LinkedIn)/);
+    expect(cleaned).not.toMatch(/^Share:/m);
+    expect(cleaned).toContain('New Zealand plans to amend the Climate Change Response Act 2002.');
+  });
+
+  it('removes the ESG News newsletter signup and editorial-team bio footer', () => {
+    const raw =
+      'The answer could affect how boards assess transition plans.\n' +
+      'Subscribe & Follow for Daily ESG Insights\n' +
+      'Stay Informed: Subscribe to the ESG News Daily Snapshot for the latest updates.\n' +
+      'Join the Conversation: Follow ESG News on LinkedIn to engage with our community.\n' +
+      'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran ' +
+      'financial journalists and sustainability analysts dedicated to providing real-time reporting.';
+    const cleaned = sanitizeArticleText(raw);
+    expect(cleaned).toContain('The answer could affect how boards assess transition plans.');
+    expect(cleaned).not.toMatch(/Subscribe & Follow/);
+    expect(cleaned).not.toMatch(/Stay Informed:/);
+    expect(cleaned).not.toMatch(/Join the Conversation:/);
+    expect(cleaned).not.toMatch(/ESG News Editorial Team is comprised of/);
+  });
+
+  it('removes inline "RELATED ARTICLE:" promo lines', () => {
+    const raw =
+      'Indonesia has already issued regulations.\n' +
+      'RELATED ARTICLE: Indonesia Launches Digital Tracker for Agricultural Commodities\n' +
+      'That local element is important.';
+    const cleaned = sanitizeArticleText(raw);
+    expect(cleaned).not.toMatch(/RELATED ARTICLE:/);
+    expect(cleaned).toContain('Indonesia has already issued regulations.');
+    expect(cleaned).toContain('That local element is important.');
+  });
+
+  it('returns empty string for a Carbon Pulse listing/ticker page (no article body)', () => {
+    // The "CP Daily News Ticker" page is a date-filter calendar widget, not an
+    // article. After chrome removal nothing real remains, so the caller can skip it.
+    const raw =
+      'Click on the coloured labels below to filter by region or topic\n' +
+      'Filter by dateClear filter×See the past posts by selecting a date in the calendar below:' +
+      '(Note: No posts before 28 April 2025)\n' +
+      'January February March April May June July August September October November December\n' +
+      '2016 2017 2018 2019 2020 2021 2022 2023 2024 2025 2026';
+    expect(sanitizeArticleText(raw).trim()).toBe('');
+  });
+
+  it('preserves a real multi-paragraph article body intact', () => {
+    const raw =
+      'New Zealand’s government plans to change climate law to stop courts from finding ' +
+      'companies liable in private cases for harm linked to greenhouse gas emissions.\n\n' +
+      'Justice Minister Paul Goldsmith said the government would amend the Climate Change ' +
+      'Response Act 2002. The change would apply to both current and future court proceedings.';
+    const cleaned = sanitizeArticleText(raw);
+    expect(cleaned).toContain('New Zealand’s government plans to change climate law');
+    expect(cleaned).toContain('Justice Minister Paul Goldsmith said the government would amend');
+    expect(cleaned).toMatch(/\n\n/); // paragraph break preserved
+  });
+
+  it('is idempotent on already-clean Trellis-style content', () => {
+    const clean =
+      'Corporate demand is driving a boom in farmland carbon credits.\n\n' +
+      'Farmers are increasingly turning to carbon markets.';
+    expect(sanitizeArticleText(clean)).toBe(clean);
+  });
+
+  it('returns empty string for empty or whitespace-only input', () => {
+    expect(sanitizeArticleText('')).toBe('');
+    expect(sanitizeArticleText('   \n\t  \n ')).toBe('');
+  });
+});

--- a/apps/news-digest/pipeline/src/helpers/__tests__/markdown.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/markdown.helpers.spec.ts
@@ -44,4 +44,37 @@ describe('buildArticleMarkdown', () => {
     expect(md).toContain('A summary of the article.');
     expect(md).toContain('## Full Article Content');
   });
+
+  it('sanitizes scraped chrome out of the full content section (regression: 2026-05-18)', () => {
+    const article: ProcessedArticle = {
+      source: 'esgnews',
+      url: 'https://esgnews.com/x/',
+      title: 'NZ Climate Law',
+      date: '2026-05-17',
+      author: 'ESG News',
+      mainTheme: 'Carbon Markets',
+      categories: '',
+      location: '',
+      summary: 'Clean summary.',
+      keyPoints: ['Point 1'],
+      segment: '',
+      fullContent:
+        'Share on Twitter\n' +
+        '<img loading="lazy" src="https://esgnews.com/x.webp" srcset="x 780w" />\n' +
+        'New Zealand plans to amend the Climate Change Response Act 2002.\n' +
+        'Subscribe & Follow for Daily ESG Insights',
+      markdownFile: '2026-05-17-nz.md',
+      notionPageId: null,
+      processedAt: '2026-05-18T10:00:00Z',
+      status: 'markdown-only',
+    };
+
+    const md = buildArticleMarkdown(article);
+
+    expect(md).not.toContain('<img');
+    expect(md).not.toContain('srcset');
+    expect(md).not.toContain('Share on Twitter');
+    expect(md).not.toContain('Subscribe & Follow');
+    expect(md).toContain('New Zealand plans to amend the Climate Change Response Act 2002.');
+  });
 });

--- a/apps/news-digest/pipeline/src/helpers/content.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/content.helpers.ts
@@ -1,0 +1,59 @@
+// Defense-in-depth sanitizer for scraped article bodies.
+//
+// Scrapers extract `fullContent` from source-site DOM. When a site changes its
+// markup (or a listing/ticker page is captured instead of an article), naive
+// whole-container `.textContent` leaks page chrome: breadcrumbs, social-share
+// buttons, <noscript> lazy-load <img> markup, author bios, newsletter signups,
+// and date-filter widgets. `notion.ts` and the S3 markdown write this verbatim.
+//
+// This is the single point that strips that chrome regardless of which scraper
+// produced it (present or future). An all-chrome page sanitizes to '' so the
+// caller can skip creating an empty/garbage article.
+
+const MONTHS =
+  'January|February|March|April|May|June|July|August|September|October|November|December';
+
+const MONTH_LIST_RE = new RegExp(`^(?:${MONTHS})(?:\\s+(?:${MONTHS}))*$`, 'i');
+const YEAR_RUN_RE = /^(?:(?:19|20)\d{2})(?:\s+(?:19|20)\d{2})+$/;
+
+// Lines that are pure site chrome, never article body.
+const BOILERPLATE_LINE_PATTERNS: readonly RegExp[] = [
+  /^Share:?$/i,
+  /^Share on (?:Facebook|Twitter|LinkedIn|X)\b/i,
+  /^Subscribe & Follow\b/i,
+  /^Stay Informed:/i,
+  /^Join the Conversation:/i,
+  /\bEditorial Team is comprised of\b/i,
+  /^RELATED ARTICLE:/i,
+  /^Click on the coloured labels\b/i,
+  /^Filter by date\b/i,
+  /\bSee the past posts by selecting a date\b/i,
+  MONTH_LIST_RE,
+  YEAR_RUN_RE,
+];
+
+function isBoilerplateLine(line: string): boolean {
+  return BOILERPLATE_LINE_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+/**
+ * Strips residual HTML markup and known site chrome from a scraped article
+ * body, collapsing CSS-layout whitespace into clean paragraphs.
+ *
+ * Returns an empty string when nothing but chrome remains (e.g. a Carbon Pulse
+ * listing/ticker page), so callers can skip it instead of publishing garbage.
+ */
+export function sanitizeArticleText(raw: string): string {
+  if (!raw) return '';
+
+  // Drop any residual tags (e.g. <img>/<br>/<p> leaked via <noscript> or a
+  // failed extraction). A space keeps adjacent words from gluing together.
+  const withoutTags = raw.replace(/<[^>]*>/g, ' ');
+
+  const cleanLines = withoutTags
+    .split('\n')
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter((line) => line.length > 0 && !isBoilerplateLine(line));
+
+  return cleanLines.join('\n\n');
+}

--- a/apps/news-digest/pipeline/src/helpers/markdown.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/markdown.helpers.ts
@@ -1,5 +1,6 @@
 import type { ProcessedArticle } from '../types.js';
 import { sourceLabel } from './source.helpers.js';
+import { sanitizeArticleText } from './content.helpers.js';
 
 const MAX_SLUG_LENGTH = 63;
 
@@ -17,6 +18,7 @@ export function slugify(title: string): string {
 export function buildArticleMarkdown(article: ProcessedArticle): string {
   const company = 'Not Applicable';
   const keyPointsList = article.keyPoints.map((p) => `- ${p}`).join('\n');
+  const cleanContent = sanitizeArticleText(article.fullContent);
 
   return `# ${article.title}
 
@@ -55,7 +57,7 @@ ${article.summary}
 
 ## Full Article Content
 
-${article.fullContent}
+${cleanContent}
 
 ---
 

--- a/apps/news-digest/pipeline/src/scraper/__tests__/carbon-pulse.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/carbon-pulse.spec.ts
@@ -1,5 +1,66 @@
-import { describe, it, expect } from 'vitest';
-import { parseHumanDate } from '../carbon-pulse.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: vi.fn(),
+  },
+}));
+
+import { chromium } from 'playwright';
+import { parseHumanDate, scrapeCarbonPulse } from '../carbon-pulse.js';
+import type { ProxyConfig, ThemeConfig } from '../../types.js';
+
+const TODAY_HUMAN = new Date().toLocaleDateString('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+function stubTheme(overrides: Partial<ThemeConfig> = {}): ThemeConfig {
+  return {
+    name: 'Methane & Super Pollutants',
+    frequency: 'daily',
+    carbonPulseSearchTerms: 'methane',
+    esgNewsSearchTerms: 'methane',
+    trellisSearchTerms: 'methane',
+    ...overrides,
+  };
+}
+
+const PROXY: ProxyConfig = { server: 'http://proxy', username: 'u', password: 'p' };
+const CREDS = { username: 'user', password: 'pass' };
+
+function mockBrowser(evaluations: Array<() => unknown>) {
+  const evalQueue = [...evaluations];
+  const locator = {
+    first: () => ({ fill: vi.fn(async () => undefined), click: vi.fn(async () => undefined) }),
+  };
+  const page = {
+    goto: vi.fn(async () => null),
+    title: vi.fn(async () => 'Carbon Pulse'),
+    url: vi.fn(() => 'https://carbon-pulse.com/login/'),
+    fill: vi.fn(async () => undefined),
+    click: vi.fn(async () => undefined),
+    waitForLoadState: vi.fn(async () => undefined),
+    waitForSelector: vi.fn(async () => undefined),
+    waitForFunction: vi.fn(async () => undefined),
+    locator: vi.fn(() => locator),
+    evaluate: vi.fn(async () => {
+      const current = evalQueue.shift();
+      return current ? current() : null;
+    }),
+  };
+  const context = {
+    addInitScript: vi.fn(async () => undefined),
+    newPage: vi.fn(async () => page),
+  };
+  const browser = {
+    newContext: vi.fn(async () => context),
+    close: vi.fn(async () => undefined),
+  };
+  vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+  return { browser, page };
+}
 
 describe('parseHumanDate', () => {
   it.each<[string, string]>([
@@ -17,4 +78,58 @@ describe('parseHumanDate', () => {
       expect(parseHumanDate(input)).toBe('');
     },
   );
+});
+
+describe('scrapeCarbonPulse', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('does NOT emit an article for a listing/ticker page (regression: "CP Daily News Ticker" 2026-05-18)', async () => {
+    mockBrowser([
+      // Search results: the link selector now matches a ticker/listing page.
+      () => [
+        {
+          url: 'https://carbon-pulse.com/cp-daily-news-ticker-may-16-2026/',
+          title: 'CP Daily News Ticker: May 16, 2026',
+        },
+      ],
+      // "Article" page: actually a date-filter calendar widget, not an article.
+      () => ({
+        content:
+          'Click on the coloured labels below to filter by region or topic\n' +
+          'Filter by dateClear filter×See the past posts by selecting a date in the calendar below:\n' +
+          'January February March April May June July August September October November December\n' +
+          '2016 2017 2018 2019 2020 2021 2022 2023 2024 2025 2026',
+        author: '',
+        date: TODAY_HUMAN,
+        categories: '',
+      }),
+    ]);
+
+    const result = await scrapeCarbonPulse([stubTheme()], new Set(), CREDS, PROXY);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('sanitizes chrome but keeps a real article body', async () => {
+    mockBrowser([
+      () => [{ url: 'https://carbon-pulse.com/real-article/', title: 'Real Carbon Article' }],
+      () => ({
+        content:
+          'Share on Facebook\n' +
+          '<img loading="lazy" src="https://carbon-pulse.com/x.webp" srcset="x 780w" />\n' +
+          'Methane emissions from landfills rose sharply in 2025, new data shows.',
+        author: 'Carbon Pulse',
+        date: TODAY_HUMAN,
+        categories: 'Methane',
+      }),
+    ]);
+
+    const result = await scrapeCarbonPulse([stubTheme()], new Set(), CREDS, PROXY);
+
+    expect(result).toHaveLength(1);
+    const body = result[0]?.fullContent ?? '';
+    expect(body).not.toContain('<img');
+    expect(body).not.toMatch(/Share on Facebook/);
+    expect(body).toContain('Methane emissions from landfills rose sharply in 2025, new data shows.');
+  });
 });

--- a/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { ThemeConfig } from '../../types.js';
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: vi.fn(),
+  },
+}));
+
+import { chromium } from 'playwright';
+import { scrapeEsgNews } from '../esg-news.js';
+
+const TODAY_ISO = new Date().toISOString().slice(0, 10);
+
+function stubTheme(overrides: Partial<ThemeConfig> = {}): ThemeConfig {
+  return {
+    name: 'Carbon Markets',
+    frequency: 'daily',
+    carbonPulseSearchTerms: 'carbon market',
+    esgNewsSearchTerms: 'carbon market',
+    trellisSearchTerms: 'carbon market',
+    ...overrides,
+  };
+}
+
+function mockBrowser(evaluations: Array<() => unknown>) {
+  const evalQueue = [...evaluations];
+  const page = {
+    goto: vi.fn(async () => null),
+    evaluate: vi.fn(async () => {
+      const current = evalQueue.shift();
+      return current ? current() : null;
+    }),
+  };
+  const browser = {
+    newPage: vi.fn(async () => page),
+    close: vi.fn(async () => undefined),
+  };
+  vi.mocked(chromium.launch).mockResolvedValue(browser as never);
+  return { browser, page };
+}
+
+describe('scrapeEsgNews', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('sanitizes scraped page chrome out of fullContent (regression: 2026-05-18 broken ESG articles)', async () => {
+    mockBrowser([
+      // Search results page: one article link.
+      () => [{ url: 'https://esgnews.com/nz/', title: 'NZ Climate Law' }],
+      // Article page: textContent of <article> leaked all the page chrome.
+      () => ({
+        content:
+          'Climate\n/\nGovernment\n/\nNews\nby ESG News Editorial Team\n' +
+          'Share:\nShare on Facebook\nShare on Twitter\nShare on LinkedIn\n' +
+          '<img loading="lazy" src="https://esgnews.com/nz.webp" srcset="https://esgnews.com/nz.webp 780w" />\n' +
+          'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.\n' +
+          'RELATED ARTICLE: New Zealand Lifts Climate Reporting Thresholds\n' +
+          'Subscribe & Follow for Daily ESG Insights\n' +
+          'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran journalists.',
+        author: 'ESG News Editorial Team',
+        date: TODAY_ISO,
+      }),
+    ]);
+
+    const result = await scrapeEsgNews([stubTheme()], new Set(), []);
+
+    expect(result).toHaveLength(1);
+    const body = result[0]?.fullContent ?? '';
+    expect(body).not.toContain('<img');
+    expect(body).not.toContain('srcset');
+    expect(body).not.toMatch(/Share on (Facebook|Twitter|LinkedIn)/);
+    expect(body).not.toMatch(/RELATED ARTICLE:/);
+    expect(body).not.toMatch(/Subscribe & Follow/);
+    expect(body).not.toMatch(/Editorial Team is comprised of/);
+    expect(body).toContain('New Zealand plans to amend the Climate Change Response Act 2002 to block claims.');
+  });
+
+  it('closes the browser in a finally block even when scraping throws', async () => {
+    const { browser } = mockBrowser([]);
+    browser.newPage.mockRejectedValueOnce(new Error('page creation failed'));
+    await expect(scrapeEsgNews([stubTheme()], new Set(), [])).rejects.toThrow('page creation failed');
+    expect(browser.close).toHaveBeenCalled();
+  });
+});

--- a/apps/news-digest/pipeline/src/scraper/carbon-pulse.ts
+++ b/apps/news-digest/pipeline/src/scraper/carbon-pulse.ts
@@ -1,5 +1,6 @@
 import { chromium } from 'playwright';
 import type { Page } from 'playwright';
+import { sanitizeArticleText } from '../helpers/content.helpers.js';
 import type { ProxyConfig, RawArticle, ThemeConfig } from '../types.js';
 
 const BASE_URL = 'https://carbon-pulse.com';
@@ -145,6 +146,14 @@ async function searchAndExtract(
         console.warn(`[Carbon Pulse] Article too old (${extracted.date}), skipping: ${link.url}`);
         continue;
       }
+      // The link selector can match listing/ticker pages (e.g. "CP Daily News
+      // Ticker") whose body is just a date-filter widget. Sanitization reduces
+      // those to empty — skip them instead of publishing a chrome-only page.
+      const cleanContent = sanitizeArticleText(extracted.content);
+      if (!cleanContent) {
+        console.warn(`[Carbon Pulse] No article body after sanitization (likely a listing page), skipping: ${link.url}`);
+        continue;
+      }
       articles.push({
         source: 'carbon-pulse',
         url: link.url,
@@ -154,7 +163,7 @@ async function searchAndExtract(
         mainTheme: theme.name,
         categories: extracted.categories,
         location: '',
-        fullContent: extracted.content,
+        fullContent: cleanContent,
       });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'unknown';

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -1,5 +1,6 @@
 import { chromium } from 'playwright';
 import type { Browser, Page } from 'playwright';
+import { sanitizeArticleText } from '../helpers/content.helpers.js';
 import type { RawArticle, ThemeConfig } from '../types.js';
 
 const SEARCH_URL = 'https://esgnews.com/?s=';
@@ -65,6 +66,14 @@ async function searchAndExtract(
         console.warn(`[ESG News] Article too old (${articleDate}), skipping: ${link.url}`);
         continue;
       }
+      // esgnews.com wraps breadcrumbs, share buttons, <noscript> <img> markup,
+      // newsletter signup and the editorial-team bio inside <article>, so the
+      // raw textContent is full of chrome. Strip it at the source.
+      const cleanContent = sanitizeArticleText(extracted.content);
+      if (!cleanContent) {
+        console.warn(`[ESG News] No article body after sanitization, skipping: ${link.url}`);
+        continue;
+      }
       articles.push({
         source: 'esgnews',
         url: link.url,
@@ -74,7 +83,7 @@ async function searchAndExtract(
         mainTheme: theme.name,
         categories: '',
         location: '',
-        fullContent: extracted.content,
+        fullContent: cleanContent,
       });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'unknown';


### PR DESCRIPTION
### Summary

The 2026-05-18 news digest produced badly broken Notion articles: raw page chrome (breadcrumbs, "Share on Facebook/Twitter/LinkedIn", `<noscript>` `<img>` markup, author bios, newsletter signups) dumped into the article body, plus a Carbon Pulse listing/ticker page captured as if it were an article.

Root cause: the **ESG News** and **Carbon Pulse** scrapers extracted whole-container `.textContent` with no scoping, and `notion.ts` / `markdown.helpers.ts` wrote that `fullContent` verbatim. The Trellis hardening (PR #25 / #3722) was never ported to the other two scrapers. This is recurring scraper rot triggered by source-site DOM changes — not a code regression.

This PR adds a single shared sanitization barrier and applies it defense-in-depth, so any current or future scraper is covered. It also adds the long-missing source article URL to Notion.

### Details

**New shared helper** — `helpers/content.helpers.ts` → `sanitizeArticleText()`:
- strips residual HTML tags (`<img>`, `<br>`, …)
- collapses CSS-layout whitespace into clean paragraphs
- drops known boilerplate (social share, newsletter signup, editorial-team bio, `RELATED ARTICLE:`, Carbon Pulse date-filter/month/year widgets)
- returns `''` when only chrome remains, so callers can skip non-article pages

**Wired defense-in-depth (each via TDD, RED→GREEN):**
- `distribution/notion.ts` — sanitizes `fullContent` before writing the page body
- `helpers/markdown.helpers.ts` — sanitizes the S3 markdown body
- `ai/article-processor.ts` — Claude receives clean content; fallback summary is clean (fixes garbage summaries / misclassification from chrome-laden input)
- `scraper/esg-news.ts`, `scraper/carbon-pulse.ts` — sanitize at source; **Carbon Pulse now skips listing/ticker pages** with no article body (prevents the "CP Daily News Ticker" page)

**Source article URL:** added a `Source URL` (url) property to the Notion database and `notion.ts` now populates it from `article.url`.

**Tests:** Vitest, `cd apps/news-digest/pipeline && npx vitest run` → **133 passing** (16 files; was 94). Includes regression fixtures built from the actual broken 2026-05-18 content, a new `esg-news.spec.ts`, and a Carbon Pulse listing-page regression test.

**Notion remediation already applied to the 5 pages created 2026-05-18** (not part of this code diff): 2 non-article Carbon Pulse pages archived; the 2 ESG articles rewritten with clean body + summary + Source URL + corrected theme; the a16z page left as-is (already clean).

**Deployment note:** the pipeline runs from an ECR image on ECS/EventBridge. This fix only takes effect on the scheduled run after the Docker image is rebuilt and pushed to ECR.

### Related links

- Notion DB: News extracted from Carbon Pulse with AI — https://www.notion.so/2a09703d8e9c8193b638f7bb6b1c7cd8
- Prior Trellis fix (same bug class): PR #25

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how article bodies are filtered/trimmed across scraping, AI prompting, markdown export, and Notion publishing, which could inadvertently drop valid content or skip articles if the sanitizer is too aggressive.
> 
> **Overview**
> Fixes broken news-digest outputs by introducing a shared `sanitizeArticleText()` helper and applying it **end-to-end** so scraped page chrome (share buttons, `<img>`/HTML leakage, newsletter/signup footers, etc.) no longer pollutes Claude prompts, fallback summaries, Notion page bodies, or generated markdown.
> 
> Updates the `esg-news` and `carbon-pulse` scrapers to sanitize at extraction time and **skip** pages that sanitize to empty (e.g. Carbon Pulse ticker/listing pages), and adds a new Notion `Source URL` property populated from `article.url`, with regression tests covering the 2026-05-18 incident.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75981319da8272bb84aa6a52df4d291d96a75555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->