### PR TITLE
feat(news-digest): auto-send digest email instead of creating a Gmail draft

### DIFF
--- a/apps/news-digest/_bmad-output/implementation-artifacts/1-1-email-auto-send.md
+++ b/apps/news-digest/_bmad-output/implementation-artifacts/1-1-email-auto-send.md
@@ -1,0 +1,87 @@
+---
+epic: 1
+story: 1
+slug: email-auto-send
+status: implemented
+date: 2026-05-18
+scope: apps/news-digest/pipeline
+---
+
+# Story 1.1 — Auto-send the digest email instead of creating a Gmail draft
+
+## Problem
+
+The pipeline calls `createGmailDraft` (`distribution/email.ts`) which POSTs to
+`users/me/drafts`. The digest then sits as an **unsent draft** until someone
+manually sends it. Downstream integrations read `market-intelligence@carrot.eco`
+as a source; a draft that is never sent (or sent days late) makes those
+integrations miss days and miss their ingestion time window. Slack, by contrast,
+is posted automatically in the same run.
+
+## Goal
+
+Send the digest email automatically, from the same run that posts Slack, to the
+same recipient (`GMAIL_TO`, default `market-intelligence@carrot.eco`). No manual
+step. No draft.
+
+## Decisions (locked with requester)
+
+- **Clean cutover**: `createGmailDraft` is replaced by `sendGmailMessage`; the
+  draft path is removed entirely. `SKIP_EMAIL` still skips the channel.
+- **Same run, sequential**: keep the orchestrator order Notion → email → Slack
+  (seconds apart, same run). No `Promise.all`; preserves per-channel error
+  isolation, which matches the existing resilience pattern.
+
+## Acceptance criteria
+
+1. `sendGmailMessage(html, to, date, credentials)` POSTs to
+   `https://gmail.googleapis.com/gmail/v1/users/me/messages/send` with body
+   `{ raw }` (the RFC822 message — no `{ message: { raw } }` draft envelope).
+2. Success returns `{ success: true, messageId }`. Token-refresh failure and any
+   non-2xx from Gmail return `{ success: false, error }` (no throw escapes).
+3. **Idempotency**: a same-day re-run does NOT send a second email. A new state
+   field `emailSentAt` mirrors `slackPostedAt` — if `state.emailSentAt` starts
+   with today, the email step is skipped and treated as already sent.
+4. `PipelineResult.emailDraftCreated` is renamed to `emailSent`; the summary log
+   reads `Email: sent | failed`.
+5. Old persisted state (no `emailSentAt`) still parses (Zod `.optional().default('')`).
+6. `DRY_RUN` still skips email; `SKIP_EMAIL` still skips email.
+7. Vitest green for the app; `nx lint news-digest-pipeline` clean.
+
+## Task list
+
+- [x] TDD: rewrote `distribution/__tests__/email.spec.ts` for `sendGmailMessage`
+      (endpoint, `{ raw }` body, success → `messageId`, both failure paths).
+- [x] `distribution/email.ts`: `createGmailDraft` → `sendGmailMessage`,
+      `GmailDraftResult`/`draftId` → `GmailSendResult`/`messageId`, endpoint +
+      body change. `refreshAccessToken` / `buildRawEmail` intact.
+- [x] `types.ts`: `ProcessedState.emailSentAt: string`; `PipelineResult.emailSent`.
+- [x] `config.schema.ts`: `processedStateSchema.emailSentAt` default `''`.
+- [x] `state/s3-store.ts`: `EMPTY_STATE.emailSentAt = ''` (+ spec assertions).
+- [x] `orchestrator.ts`: import + return-type rename; email block uses
+      `sendGmailMessage`, same-day guard added; `emailSentAt` persisted in both
+      `saveStateSafely` calls; all `emailDraftCreated` literals + summary log fixed.
+- [x] Verify: `npx vitest run` → 134/134 green; `pnpm nx build` green. Repo
+      `lint` target is broken at environment level (`@nx/linter:eslint`
+      resolution) — pre-existing, unrelated to this change. `tsc --noEmit`
+      surfaces only pre-existing errors in untouched files.
+- [x] Live smoke test (`scripts/test-email-send.ts`, 2026-05-18): real
+      Secrets Manager creds + new `sendGmailMessage`, sent to the authenticated
+      account's own address (resolved at runtime via `users/me/profile`), NOT
+      the prod list. Result: `success` with a returned `messageId`. Confirms
+      scope, token, send path, and template rendering end-to-end.
+- [ ] Deploy: `pnpm nx docker-push news-digest-pipeline` (ECR `:latest`) — the
+      scheduled run only picks up the change after this. Pending go-ahead.
+
+## Out of scope / follow-up (not code in this story)
+
+- **OAuth scope risk — VERIFIED CLOSED (2026-05-18).** The `news-digest/gmail-credentials`
+  secret's refresh token was inspected via token refresh + tokeninfo. Granted
+  scope is `https://www.googleapis.com/auth/gmail.compose`, which the Gmail API
+  authorizes for `users.messages.send` (the official `gmail.compose` description
+  is "Create, read, update, and delete drafts. Send messages and drafts").
+  No re-consent or secret rotation needed. Refresh token still valid (no
+  `invalid_grant`).
+- **Deploy** — the scheduled run uses the ECR `:latest` image. This code change
+  has no effect on the daily run until `pnpm nx docker-push news-digest-pipeline`
+  is run. Separate, explicit step.

--- a/apps/news-digest/_bmad-output/project-context.md
+++ b/apps/news-digest/_bmad-output/project-context.md
@@ -15,7 +15,7 @@ _Scope: `apps/news-digest/` only (`pipeline` + `infra`). Not the rest of the mid
 
 ## 1. What this is
 
-A daily news-intelligence pipeline. A scheduled **ECS Fargate** task (EventBridge cron) scrapes climate/circularity sources (Carbon Pulse, ESG News, Trellis, Substack RSS), cross-source dedups, summarizes each article with **Claude Haiku**, persists state + markdown to **S3**, then distributes to **Notion**, a **Gmail draft**, and **Slack**. There is no server and no API surface — it is a batch job that runs once per day and exits.
+A daily news-intelligence pipeline. A scheduled **ECS Fargate** task (EventBridge cron) scrapes climate/circularity sources (Carbon Pulse, ESG News, Trellis, Substack RSS), cross-source dedups, summarizes each article with **Claude Haiku**, persists state + markdown to **S3**, then distributes to **Notion**, an **auto-sent Gmail message** (`messages/send` — no manual draft step), and **Slack**. There is no server and no API surface — it is a batch job that runs once per day and exits.
 
 Two Nx projects:
 
@@ -96,7 +96,7 @@ Two Nx projects:
 
 ## 6. Distribution & flags
 
-- Channels: Notion DB (default id in `envSchema`), Gmail draft (`GMAIL_TO`), Slack (`SLACK_CHANNEL_ID`). Slack is skipped if already posted today (`slackPostedAt`).
+- Channels: Notion DB (default id in `envSchema`), Gmail auto-send to `GMAIL_TO` (`sendGmailMessage` → `users/me/messages/send`; **not** a draft), Slack (`SLACK_CHANNEL_ID`). Both Gmail and Slack are skipped if already done today — `state.emailSentAt` mirrors `slackPostedAt` to prevent a same-day re-run double-sending to the source inbox that feeds downstream email-reading integrations. Gmail send needs the `gmail.send` (or broader) OAuth scope on the Secrets Manager refresh token; a 403 "insufficient permission" means the consent must be re-granted and the refresh token rotated — not a code bug.
 - Flags (env, string `'true'`): `DRY_RUN` (skip ALL distribution), `SKIP_NOTION`, `SKIP_EMAIL`, `SKIP_SLACK`. Use `DRY_RUN=true` + a throwaway state key for safe validation; combine `SKIP_*` to exercise one channel.
 
 ## 7. Known fragilities / gotchas

--- a/apps/news-digest/infra/src/secrets.tf
+++ b/apps/news-digest/infra/src/secrets.tf
@@ -25,7 +25,7 @@ resource "aws_secretsmanager_secret" "notion_token" {
 resource "aws_secretsmanager_secret" "gmail_credentials" {
   name        = "${var.app_name}/gmail-credentials"
   description = "Gmail OAuth2 credentials"
-  tags        = { Name = "${var.app_name}/gmail-credentials", Purpose = "Gmail draft creation" }
+  tags        = { Name = "${var.app_name}/gmail-credentials", Purpose = "Gmail digest auto-send" }
 }
 
 resource "aws_secretsmanager_secret" "proxy" {

--- a/apps/news-digest/pipeline/scripts/test-email-send.ts
+++ b/apps/news-digest/pipeline/scripts/test-email-send.ts
@@ -92,6 +92,32 @@ async function refreshAccessToken(clientId: string, clientSecret: string, refres
   return ((await response.json()) as { access_token: string }).access_token;
 }
 
+/**
+ * Returns the recipient as a single normalized bare email address, or throws.
+ * Rejects comma-separated lists, display names ("Name <addr>"), surrounding or
+ * embedded whitespace, casing variants of the prod list, and anything that is
+ * not exactly one address — so the prod list cannot slip through `to`.
+ */
+function safeTestRecipient(rawValue: string): string {
+  const collapsed = rawValue.trim().replace(/\s+/g, ' ');
+
+  if (collapsed.includes(',')) {
+    throw new Error(`Test recipient must be a single address, got a list: "${rawValue}".`);
+  }
+  if (/[<>]/.test(collapsed) || collapsed.includes(' ')) {
+    throw new Error(`Test recipient must be a bare email address (no display name): "${rawValue}".`);
+  }
+
+  const address = collapsed.toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(address)) {
+    throw new Error(`Test recipient is not a valid email address: "${rawValue}".`);
+  }
+  if (address === PROD_LIST.toLowerCase()) {
+    throw new Error(`Refusing to send the smoke test to the production list (${PROD_LIST}).`);
+  }
+  return address;
+}
+
 async function main(): Promise<void> {
   const today = new Date().toISOString().slice(0, 10);
 
@@ -107,11 +133,7 @@ async function main(): Promise<void> {
 
   const accessToken = await refreshAccessToken(credentials.clientId, credentials.clientSecret, credentials.refreshToken);
   const ownEmail = await resolveOwnEmail(accessToken);
-  const to = process.env.TEST_EMAIL_TO ?? ownEmail;
-
-  if (to === PROD_LIST) {
-    throw new Error(`Refusing to send the smoke test to the production list (${PROD_LIST}).`);
-  }
+  const to = safeTestRecipient(process.env.TEST_EMAIL_TO ?? ownEmail);
 
   const html = buildEmailHtml(syntheticArticles(today), today);
 

--- a/apps/news-digest/pipeline/scripts/test-email-send.ts
+++ b/apps/news-digest/pipeline/scripts/test-email-send.ts
@@ -1,0 +1,134 @@
+/**
+ * Manual smoke test for the auto-send change (BMAD story 1.1).
+ *
+ * Sends ONE real digest email — using the production Gmail credentials from
+ * Secrets Manager and the new `sendGmailMessage` code path — to the
+ * authenticated account's OWN address (fetched via users/me/profile), NOT to
+ * the production distribution (`market-intelligence@carrot.eco`). It does not
+ * scrape, touch Notion/Slack, or read/write S3 state.
+ *
+ * Run (from apps/news-digest/pipeline):
+ *   npx esbuild scripts/test-email-send.ts --bundle --platform=node \
+ *     --target=node22 --outfile=dist/scripts/test-email-send.mjs \
+ *     --format=esm --external:@aws-sdk/* \
+ *   && node dist/scripts/test-email-send.mjs
+ *
+ * Optional: TEST_EMAIL_TO=<addr> overrides the recipient (still never the prod list).
+ */
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import { gmailSecretSchema } from '../src/config.schema.js';
+import { sendGmailMessage } from '../src/distribution/email.js';
+import { buildEmailHtml } from '../src/distribution/email-template.helpers.js';
+import type { ProcessedArticle } from '../src/types.js';
+
+const SECRET_ID = process.env.GMAIL_SECRET_ID ?? 'news-digest/gmail-credentials';
+const REGION = process.env.AWS_REGION ?? 'us-east-1';
+const PROD_LIST = 'market-intelligence@carrot.eco';
+
+function syntheticArticles(today: string): ProcessedArticle[] {
+  const base = {
+    categories: '',
+    location: '',
+    fullContent: '',
+    notionPageId: null,
+    processedAt: `${today}T09:00:00.000Z`,
+    status: 'markdown-only' as const,
+  };
+  return [
+    {
+      ...base,
+      source: 'carbon-pulse',
+      url: 'https://example.com/test-article-one',
+      title: 'Sample headline one for the auto-send smoke test',
+      date: today,
+      author: 'Test Desk',
+      mainTheme: 'Carbon Markets',
+      summary: 'This is synthetic summary text used only to validate that the digest email renders and is delivered through the automatic send path.',
+      keyPoints: ['First synthetic key point', 'Second synthetic key point'],
+      segment: 'Policy & Regulation',
+      markdownFile: `${today}-sample-one.md`,
+    },
+    {
+      ...base,
+      source: 'esgnews',
+      url: 'https://example.com/test-article-two',
+      title: 'Sample headline two for the auto-send smoke test',
+      date: today,
+      author: 'Test Desk',
+      mainTheme: 'Circular Economy',
+      summary: 'Second synthetic article. No real data, no PII — purely a delivery and rendering check for the test recipient.',
+      keyPoints: [],
+      segment: '',
+      markdownFile: `${today}-sample-two.md`,
+    },
+  ];
+}
+
+async function resolveOwnEmail(accessToken: string): Promise<string> {
+  const response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/profile', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok) {
+    throw new Error(`getProfile failed (HTTP ${response.status}): ${await response.text()}`);
+  }
+  const data = (await response.json()) as { emailAddress: string };
+  return data.emailAddress;
+}
+
+async function refreshAccessToken(clientId: string, clientSecret: string, refreshToken: string): Promise<string> {
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }).toString(),
+  });
+  if (!response.ok) {
+    throw new Error(`Token refresh failed (HTTP ${response.status}): ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}
+
+async function main(): Promise<void> {
+  const today = new Date().toISOString().slice(0, 10);
+
+  const client = new SecretsManagerClient({ region: REGION });
+  const raw = await client.send(new GetSecretValueCommand({ SecretId: SECRET_ID }));
+  if (!raw.SecretString) throw new Error(`Secret ${SECRET_ID} has no value`);
+  const parsed = gmailSecretSchema.parse(JSON.parse(raw.SecretString));
+  const credentials = {
+    clientId: parsed.client_id,
+    clientSecret: parsed.client_secret,
+    refreshToken: parsed.refresh_token,
+  };
+
+  const accessToken = await refreshAccessToken(credentials.clientId, credentials.clientSecret, credentials.refreshToken);
+  const ownEmail = await resolveOwnEmail(accessToken);
+  const to = process.env.TEST_EMAIL_TO ?? ownEmail;
+
+  if (to === PROD_LIST) {
+    throw new Error(`Refusing to send the smoke test to the production list (${PROD_LIST}).`);
+  }
+
+  const html = buildEmailHtml(syntheticArticles(today), today);
+
+  console.log(`Authenticated account: ${ownEmail}`);
+  console.log(`Sending smoke-test digest to: ${to}`);
+
+  const result = await sendGmailMessage(html, to, today, credentials);
+
+  if (result.success) {
+    console.log(`✅ SENT — messageId=${result.messageId}, recipient=${to}`);
+  } else {
+    console.error(`❌ FAILED — ${result.error}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(`❌ ERROR — ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/apps/news-digest/pipeline/src/config.schema.ts
+++ b/apps/news-digest/pipeline/src/config.schema.ts
@@ -60,4 +60,5 @@ export const processedStateSchema = z.object({
   })),
   themeLastProcessed: z.record(z.string(), z.string()),
   slackPostedAt: z.string().optional().default(''),
+  emailSentAt: z.string().optional().default(''),
 });

--- a/apps/news-digest/pipeline/src/distribution/__tests__/email.spec.ts
+++ b/apps/news-digest/pipeline/src/distribution/__tests__/email.spec.ts
@@ -1,25 +1,45 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createGmailDraft } from '../email.js';
+import { sendGmailMessage } from '../email.js';
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-describe('createGmailDraft', () => {
+const credentials = { clientId: 'client-id', clientSecret: 'client-secret', refreshToken: 'refresh-token' };
+
+describe('sendGmailMessage', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('creates a draft via Gmail API', async () => {
+  it('sends the email via the Gmail messages/send endpoint', async () => {
     mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ access_token: 'fresh-token' }) });
-    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 'draft-123' }) });
-    // cspell:disable-next-line
-    const result = await createGmailDraft('<html>Digest</html>', 'test@test.com', '2026-03-27', { clientId: 'cid', clientSecret: 'csecret', refreshToken: 'rtoken' });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 'msg-123' }) });
+
+    const result = await sendGmailMessage('<html>Digest</html>', 'test@test.com', '2026-03-27', credentials);
+
     expect(result.success).toBe(true);
-    expect(result.draftId).toBe('draft-123');
+    expect(result.messageId).toBe('msg-123');
+
+    const [url, init] = mockFetch.mock.calls[1]!;
+    expect(url).toBe('https://gmail.googleapis.com/gmail/v1/users/me/messages/send');
+    const body = JSON.parse((init as { body: string }).body) as Record<string, unknown>;
+    expect(body).toHaveProperty('raw');
+    expect(body).not.toHaveProperty('message');
   });
 
   it('returns failure when token refresh fails', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 401, text: () => Promise.resolve('invalid_grant') });
-    // cspell:disable-next-line
-    const result = await createGmailDraft('<html>Digest</html>', 'test@test.com', '2026-03-27', { clientId: 'cid', clientSecret: 'csecret', refreshToken: 'rtoken' });
+
+    const result = await sendGmailMessage('<html>Digest</html>', 'test@test.com', '2026-03-27', credentials);
+
     expect(result.success).toBe(false);
+  });
+
+  it('returns failure when the Gmail API rejects the send', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ access_token: 'fresh-token' }) });
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403, text: () => Promise.resolve('insufficient permission') });
+
+    const result = await sendGmailMessage('<html>Digest</html>', 'test@test.com', '2026-03-27', credentials);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('403');
   });
 });

--- a/apps/news-digest/pipeline/src/distribution/email.ts
+++ b/apps/news-digest/pipeline/src/distribution/email.ts
@@ -4,9 +4,9 @@ interface GmailCredentials {
   readonly refreshToken: string;
 }
 
-interface GmailDraftResult {
+interface GmailSendResult {
   readonly success: boolean;
-  readonly draftId?: string;
+  readonly messageId?: string;
   readonly error?: string;
 }
 
@@ -56,12 +56,12 @@ function buildRawEmail(htmlBody: string, to: string, date: string): string {
   return Buffer.from(message).toString('base64url');
 }
 
-export async function createGmailDraft(
+export async function sendGmailMessage(
   htmlBody: string,
   to: string,
   date: string,
   credentials: GmailCredentials,
-): Promise<GmailDraftResult> {
+): Promise<GmailSendResult> {
   let accessToken: string;
 
   try {
@@ -73,13 +73,13 @@ export async function createGmailDraft(
   try {
     const raw = buildRawEmail(htmlBody, to, date);
 
-    const response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/drafts', {
+    const response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ message: { raw } }),
+      body: JSON.stringify({ raw }),
     });
 
     if (!response.ok) {
@@ -88,7 +88,7 @@ export async function createGmailDraft(
     }
 
     const data = (await response.json()) as { id: string };
-    return { success: true, draftId: data.id };
+    return { success: true, messageId: data.id };
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'unknown';
     return { success: false, error: msg };

--- a/apps/news-digest/pipeline/src/orchestrator.ts
+++ b/apps/news-digest/pipeline/src/orchestrator.ts
@@ -9,7 +9,7 @@ import { scrapeSubstack } from './scraper/substack.js';
 import { processArticle } from './ai/article-processor.js';
 import { postSlackDigest } from './distribution/slack.js';
 import { createNotionPage } from './distribution/notion.js';
-import { createGmailDraft } from './distribution/email.js';
+import { sendGmailMessage } from './distribution/email.js';
 import { buildEmailHtml } from './distribution/email-template.helpers.js';
 import { THEMES, SUBSTACK_PUBLICATIONS } from './config.constants.js';
 import type { PipelineResult, ProcessedArticle, ProcessedState, RawArticle, Secrets } from './types.js';
@@ -45,14 +45,14 @@ async function distributeArticles(
   updatedArticles: ProcessedArticle[];
   notionCreated: number;
   notionFailed: number;
-  emailDraftCreated: boolean;
+  emailSent: boolean;
   slackPosted: boolean;
 }> {
   const updatedArticles = [...articles];
 
   if (config.dryRun) {
     console.log('[DRY RUN] Skipping Notion, email, and Slack distribution.');
-    return { updatedArticles, notionCreated: 0, notionFailed: 0, emailDraftCreated: false, slackPosted: false };
+    return { updatedArticles, notionCreated: 0, notionFailed: 0, emailSent: false, slackPosted: false };
   }
 
   // Notion — parallel with concurrency limit
@@ -91,19 +91,22 @@ async function distributeArticles(
   }
 
   // Email
-  let emailDraftCreated = false;
+  let emailSent = false;
   if (config.skipEmail) {
     console.log('[SKIP] Email distribution disabled.');
+  } else if (state.emailSentAt.startsWith(today)) {
+    console.log('Digest email already sent today — skipping.');
+    emailSent = true;
   } else {
-    console.log('Creating Gmail draft...');
+    console.log('Sending digest email...');
     try {
       const html = buildEmailHtml(updatedArticles, today);
-      const emailResult = await createGmailDraft(html, config.gmailTo, today, config.secrets.gmail);
-      emailDraftCreated = emailResult.success;
+      const emailResult = await sendGmailMessage(html, config.gmailTo, today, config.secrets.gmail);
+      emailSent = emailResult.success;
       if (!emailResult.success) errors.push(`Gmail: ${emailResult.error}`);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : 'unknown';
-      errors.push(`Gmail draft failed: ${msg}`);
+      errors.push(`Gmail send failed: ${msg}`);
     }
   }
 
@@ -126,7 +129,7 @@ async function distributeArticles(
     }
   }
 
-  return { updatedArticles, notionCreated, notionFailed, emailDraftCreated, slackPosted };
+  return { updatedArticles, notionCreated, notionFailed, emailSent, slackPosted };
 }
 
 function pruneOldArticles(articles: readonly ProcessedArticle[]): ProcessedArticle[] {
@@ -158,7 +161,7 @@ function logSummary(result: PipelineResult, isRerun: boolean): void {
     console.log(`Claude: ${result.claudeProcessed} processed, ${result.claudeFallbacks} fallbacks`);
   }
   console.log(`Notion: ${result.notionCreated} created, ${result.notionFailed} failed`);
-  console.log(`Email draft: ${result.emailDraftCreated ? 'created' : 'failed'}`);
+  console.log(`Email: ${result.emailSent ? 'sent' : 'failed'}`);
   console.log(`Slack: ${result.slackPosted ? 'posted' : 'failed'}`);
   if (result.errors.length > 0) {
     console.log(`Errors: ${result.errors.length}`);
@@ -195,6 +198,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       processedArticles: pruneOldArticles(mergedArticles),
       themeLastProcessed: state.themeLastProcessed,
       slackPostedAt: dist.slackPosted ? new Date().toISOString() : state.slackPostedAt,
+      emailSentAt: dist.emailSent ? new Date().toISOString() : state.emailSentAt,
     }, errors);
 
     const articlesBySource: Record<string, number> = {};
@@ -206,7 +210,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       steps: [], articlesScraped: todayArticles.length, articlesBySource,
       deduped: 0, claudeProcessed: 0, claudeFallbacks: 0,
       notionCreated: dist.notionCreated, notionFailed: dist.notionFailed,
-      emailDraftCreated: dist.emailDraftCreated, slackPosted: dist.slackPosted, errors,
+      emailSent: dist.emailSent, slackPosted: dist.slackPosted, errors,
     };
     logSummary(result, true);
     return result;
@@ -278,7 +282,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     return {
       steps: [], articlesScraped: 0, articlesBySource: { 'carbon-pulse': 0, esgnews: 0, trellis: 0, 'a16z-crypto': 0 },
       deduped: 0, claudeProcessed: 0, claudeFallbacks: 0, notionCreated: 0, notionFailed: 0,
-      emailDraftCreated: false, slackPosted: false, errors,
+      emailSent: false, slackPosted: false, errors,
     };
   }
 
@@ -353,6 +357,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     processedArticles: pruneOldArticles([...state.processedArticles, ...dist.updatedArticles]),
     themeLastProcessed: updatedThemes,
     slackPostedAt: dist.slackPosted ? new Date().toISOString() : state.slackPostedAt,
+    emailSentAt: dist.emailSent ? new Date().toISOString() : state.emailSentAt,
   }, errors);
 
   // Summary
@@ -365,7 +370,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     steps: [], articlesScraped: kept.length, articlesBySource,
     deduped: removed.length, claudeProcessed, claudeFallbacks,
     notionCreated: dist.notionCreated, notionFailed: dist.notionFailed,
-    emailDraftCreated: dist.emailDraftCreated, slackPosted: dist.slackPosted, errors,
+    emailSent: dist.emailSent, slackPosted: dist.slackPosted, errors,
   };
   logSummary(result, false);
   return result;

--- a/apps/news-digest/pipeline/src/state/__tests__/s3-store.spec.ts
+++ b/apps/news-digest/pipeline/src/state/__tests__/s3-store.spec.ts
@@ -22,7 +22,7 @@ describe('S3Store', () => {
     error.name = 'NoSuchKey';
     mockSend.mockRejectedValueOnce(error);
     const state = await store.loadState('state.json');
-    expect(state).toEqual({ processedArticles: [], themeLastProcessed: {}, slackPostedAt: '' });
+    expect(state).toEqual({ processedArticles: [], themeLastProcessed: {}, slackPostedAt: '', emailSentAt: '' });
   });
 
   it('loadState parses and returns existing state', async () => {
@@ -116,7 +116,7 @@ describe('S3Store', () => {
 
   it('saveState uploads JSON to S3', async () => {
     mockSend.mockResolvedValueOnce({});
-    const state = { processedArticles: [], themeLastProcessed: {}, slackPostedAt: '' };
+    const state = { processedArticles: [], themeLastProcessed: {}, slackPostedAt: '', emailSentAt: '' };
     await store.saveState('state.json', state);
     expect(mockSend).toHaveBeenCalledOnce();
   });

--- a/apps/news-digest/pipeline/src/state/s3-store.ts
+++ b/apps/news-digest/pipeline/src/state/s3-store.ts
@@ -6,6 +6,7 @@ const EMPTY_STATE: ProcessedState = {
   processedArticles: [],
   themeLastProcessed: {},
   slackPostedAt: '',
+  emailSentAt: '',
 };
 
 export class S3Store {

--- a/apps/news-digest/pipeline/src/types.ts
+++ b/apps/news-digest/pipeline/src/types.ts
@@ -33,6 +33,7 @@ export interface ProcessedState {
   readonly processedArticles: readonly ProcessedArticle[];
   readonly themeLastProcessed: Readonly<Record<string, string>>;
   readonly slackPostedAt: string;
+  readonly emailSentAt: string;
 }
 
 export type ThemeFrequency = 'daily' | 'weekly' | 'monthly';
@@ -75,7 +76,7 @@ export interface PipelineResult {
   readonly claudeFallbacks: number;
   readonly notionCreated: number;
   readonly notionFailed: number;
-  readonly emailDraftCreated: boolean;
+  readonly emailSent: boolean;
   readonly slackPosted: boolean;
   readonly errors: readonly string[];
 }


### PR DESCRIPTION
### Summary

Switch the news-digest email distribution from a manual **Gmail draft** to an
**automatic send**, delivered in the same run as the Slack post. The draft sat
unsent until someone sent it by hand, so downstream integrations that read
`market-intelligence@carrot.eco` as a source were missing days and their
ingestion window.

### Details

- `distribution/email.ts`: `createGmailDraft` (`users/me/drafts`) →
  `sendGmailMessage` (`users/me/messages/send`, body `{ raw }`), returning a
  `messageId`. `refreshAccessToken` / `buildRawEmail` unchanged.
- **Idempotency**: new `state.emailSentAt` mirrors `slackPostedAt`. A same-day
  re-run skips the email instead of double-sending to the source inbox that
  feeds downstream email-reading integrations. Persisted in both state-save
  paths; the Zod field is `.optional().default('')` so existing state still
  parses. `PipelineResult.emailDraftCreated` → `emailSent`.
- Clean cutover (no draft mode kept). `SKIP_EMAIL` / `DRY_RUN` still apply.
- Infra: corrected the now-stale `gmail_credentials` secret tag.
- `scripts/test-email-send.ts`: a smoke test that sends one real digest using
  the production Secrets Manager credentials and the new send path, to the
  authenticated account's **own** address (refuses the prod list), with no
  scraping / Notion / Slack / S3.

**Verification**

- Vitest `134/134` green (incl. 3 new `sendGmailMessage` tests); `nx build` green.
- OAuth scope checked against the real secret: granted scope is
  `gmail.compose`, which the Gmail API authorizes for `messages.send` — no
  re-consent or token rotation needed; refresh token still valid.
- Live smoke test sent successfully to the authenticated account's own inbox
  (not the prod list); rendering confirmed visually.

> ⚠️ **Post-merge deploy required.** The scheduled run uses the ECR `:latest`
> image; this change has no effect on the daily run until
> `pnpm nx docker-push news-digest-pipeline` is run after merge.

### Related links

- BMAD story: `apps/news-digest/_bmad-output/implementation-artifacts/1-1-email-auto-send.md`

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the pipeline from creating Gmail drafts to sending real emails via `messages/send`, which can affect production communications if misconfigured despite added same-day idempotency guards.
> 
> **Overview**
> **News-digest now auto-sends the digest email** instead of creating a Gmail draft: `createGmailDraft` is replaced with `sendGmailMessage`, using Gmail’s `users/me/messages/send` endpoint and a `{ raw }` payload, returning a `messageId`.
> 
> Adds **email idempotency** by persisting `emailSentAt` in processed state (Zod defaulted for backward compatibility) and skipping the email step on same-day re-runs; pipeline results/logging are renamed from `emailDraftCreated` to `emailSent`.
> 
> Includes updated Vitest coverage for the send path, a new manual smoke-test script (`scripts/test-email-send.ts`), and a small infra tag update for the Gmail credentials secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0e26561d11c669aa52b191e84c0ec63dada9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->