### PR TITLE
Migrate ESG News scraper from Playwright to Firecrawl

### DIFF
--- a/apps/news-digest/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/apps/news-digest/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,10 @@
+# Deferred Work
+
+Pre-existing issues surfaced incidentally during review — not caused by the work that exposed them.
+
+## `isDuplicateOfCarbonPulse` heuristic is asymmetric / false-positive-prone
+
+- **Surfaced by:** blind-hunter review of `spec-firecrawl-esgnews-scraper` (2026-05-18).
+- **Where:** `apps/news-digest/pipeline/src/scraper/esg-news.ts` (`isDuplicateOfCarbonPulse`) — logic copied verbatim from the original Playwright scraper; **not introduced** by the Firecrawl migration.
+- **Issue:** overlap ratio is `overlap / cpWords.size` (coverage of the Carbon Pulse title), not a symmetric/Jaccard similarity. A short CP title (e.g. "Carbon Markets Update") whose long words all appear in a longer, topically-different ESG title yields ratio 1.0 → the ESG article is dropped. Words are filtered to `length > 3`; threshold `>= 0.5`.
+- **Suggested fix (later, focused):** use `overlap / Math.min(cpWords.size, esgWords.length)` or a Jaccard ratio, and require `cpWords.size >= 3` before allowing a match. Add a short-CP-title false-positive regression test. Note the same dedup heuristic may exist in other scrapers — fix consistently.

--- a/apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-esgnews-scraper.md
+++ b/apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-esgnews-scraper.md
@@ -1,0 +1,119 @@
+---
+title: 'Migrate ESG News scraper from Playwright to Firecrawl'
+type: 'feature'
+created: '2026-05-18'
+status: 'done'
+baseline_commit: '0b738c4d4b67e5353ebca1715bdaeedbc1f59168'
+context:
+  - '{project-root}/apps/news-digest/_bmad-output/notes/spike-firecrawl-esgnews-2026-05-18.md'
+  - '{project-root}/apps/news-digest/_bmad-output/project-context.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The ESG News scraper uses Playwright with hand-written CSS selectors (`article a`, `time`, `.author`) that break whenever the site changes layout, causing recurring reactive maintenance. ESG News is ~43% of digest volume.
+
+**Approach:** Replace Playwright with Firecrawl HTTP API (validated in the Step 0 spike): `search` for layout-resilient discovery, `scrape` (markdown) for content, keeping the existing `sanitizeArticleText` barrier. No auth/seat-cap on ESG News, so it is migratable now (Carbon Pulse and Trellis are out of scope).
+
+## Boundaries & Constraints
+
+**Always:** Preserve the `RawArticle` output shape and orchestrator resilience contract (a scraper failure must not crash the pipeline). Keep `sanitizeArticleText` as the defense-in-depth barrier. Keep `MAX_ARTICLES_PER_THEME`, `MAX_ARTICLE_AGE_DAYS`, the Carbon-Pulse dup-title filter, `processedUrls` filtering, and the empty-after-sanitize skip. Firecrawl called via `fetch` mirroring `src/ai/article-processor.ts` (try/catch, check `response.ok`). Firecrawl API v2.
+
+**Ask First:** Making `FIRECRAWL_API_KEY_SECRET_ARN` a *required* env var (would break the deployed pipeline before the secret exists). Default: make it optional.
+
+**Never:** Touch Carbon Pulse (blocked on a subscription seat cap), Substack (stays RSS), or Trellis. No Firecrawl CLI in production code. No real network in tests.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Happy path | theme with results, fresh article | `RawArticle` with sanitized `fullContent`, `source:'esgnews'` | N/A |
+| Already processed | result url in `processedUrls` | skipped | N/A |
+| CP duplicate | title ≥50% word overlap with a `cpTitles` entry | skipped | N/A |
+| Stale article | published > `MAX_ARTICLE_AGE_DAYS` ago | skipped | N/A |
+| Chrome-only page | scrape markdown sanitizes to `''` | skipped (no empty article) | N/A |
+| Search API failure | non-2xx / network error from `/v2/search` | theme yields 0 articles, continue other themes | logged, no throw past theme loop |
+| Scrape API failure | non-2xx / network error from `/v2/scrape` | that article skipped | logged per-article |
+| Missing API key | firecrawl key empty | `scrapeEsgNews` throws once; orchestrator try/catch logs it, pipeline continues | non-breaking |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `apps/news-digest/pipeline/src/scraper/esg-news.ts` -- rewrite: Playwright → Firecrawl search+scrape
+- `apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts` -- NEW: `firecrawlSearch`/`firecrawlScrape` fetch wrappers (reusable for later Trellis migration)
+- `apps/news-digest/pipeline/src/config.schema.ts` -- add optional `FIRECRAWL_API_KEY_SECRET_ARN` to `envSchema`
+- `apps/news-digest/pipeline/src/types.ts` -- add `firecrawlApiKey: string` to `Secrets`
+- `apps/news-digest/pipeline/src/main.ts` -- conditionally load firecrawl secret in `loadSecrets`
+- `apps/news-digest/pipeline/src/orchestrator.ts` -- pass `config.secrets.firecrawlApiKey` to `scrapeEsgNews` (one call site)
+- `apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts` -- rewrite: mock `fetch`
+- `apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts` -- NEW
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `src/helpers/firecrawl.helpers.ts` -- add `firecrawlSearch(query, apiKey)` → `{url,title}[]` from `data.web[]`, and `firecrawlScrape(url, apiKey)` → `{markdown, publishedTime, author}` from `data.markdown`/`data.metadata`; throw typed `FirecrawlError` on missing key or non-2xx
+- [x] `src/scraper/esg-news.ts` -- rewrote `scrapeEsgNews(themes, processedUrls, cpTitles, firecrawlApiKey)`: per theme `firecrawlSearch("site:esgnews.com "+esgNewsSearchTerms)`; reused filter/dedup/age/sanitize logic; date from scrape metadata `article:published_time` else today; per-theme + per-article try/catch
+- [x] `src/config.schema.ts` / `src/types.ts` / `src/main.ts` -- optional `FIRECRAWL_API_KEY_SECRET_ARN`; `Secrets.firecrawlApiKey`; conditional fetch (empty string if ARN unset)
+- [x] `src/orchestrator.ts` -- passes `config.secrets.firecrawlApiKey` into `scrapeEsgNews` (one call site)
+- [x] `src/scraper/__tests__/esg-news.spec.ts` + `src/helpers/__tests__/firecrawl.helpers.spec.ts` -- every I/O Matrix row covered with `fetch` mocked
+
+**Acceptance Criteria:**
+- Given the firecrawl key is unset, when the pipeline runs, then ESG News logs an error and the rest of the pipeline still completes (no crash).
+- Given Firecrawl returns results, when `scrapeEsgNews` runs, then returned articles are identical in shape to the previous Playwright output (same `RawArticle` fields, sanitized content) and `orchestrator.ts` needs no logic change beyond passing the key.
+- Given the full suite, when `npx vitest run` executes in `apps/news-digest/pipeline`, then all tests pass with no real network.
+
+## Design Notes
+
+Firecrawl v2 (validated in spike): `POST https://api.firecrawl.dev/v2/search` `{query,limit}` → `{data:{web:[{url,title,description}]}}`; `POST https://api.firecrawl.dev/v2/scrape` `{url,formats:["markdown"],onlyMainContent:true}` → `{data:{markdown,metadata}}`. Auth: `Authorization: Bearer <key>`. Cost note (spike): plain markdown scrape ≈1cr (kept), `/extract` not used here (premium). Deploy gate: the `news-digest/firecrawl-api-key` secret is not yet provisioned in AWS — code ships deployable; infra/secret is a separate prerequisite.
+
+## Verification
+
+**Commands:**
+- `cd apps/news-digest/pipeline && npx vitest run` -- ✅ 152/152 passed (17 files; +6 review-driven tests; no regressions)
+- `pnpm nx build news-digest-pipeline` -- ✅ esbuild bundle succeeded
+- `pnpm nx lint news-digest-pipeline` -- ⚠️ NOT RUNNABLE in this environment: nx fails with `Unable to resolve @nx/linter:eslint`; direct `eslint` reports these paths as `File ignored because of a matching ignore pattern`; the `oxlint` target has no config. Pre-existing tooling state, unrelated to this change. Conventions followed manually (ESM `.js` imports, explicit return types, `readonly`, mirrors `ai/article-processor.ts`). Commit-time `cspell`/`commitlint` hooks still apply.
+
+## Suggested Review Order
+
+**Firecrawl client (design entry point)**
+
+- Start here: the v2 `fetch` client + typed error — the whole design pivots on this
+  [`firecrawl.helpers.ts:84`](../../pipeline/src/helpers/firecrawl.helpers.ts#L84)
+- Resilience core: AbortSignal timeout, network-error + non-JSON wrapping into `FirecrawlError`
+  [`firecrawl.helpers.ts:43`](../../pipeline/src/helpers/firecrawl.helpers.ts#L43)
+- `FirecrawlError` carries `status` so callers can act on 402/429
+  [`firecrawl.helpers.ts:16`](../../pipeline/src/helpers/firecrawl.helpers.ts#L16)
+
+**ESG News scraper rewrite**
+
+- New discovery+extract loop replacing Playwright; same `RawArticle` contract
+  [`esg-news.ts:28`](../../pipeline/src/scraper/esg-news.ts#L28)
+- Freshness fix: skip undated articles instead of stamping "today" (carbon-pulse parity)
+  [`esg-news.ts:57`](../../pipeline/src/scraper/esg-news.ts#L57)
+- Quota/rate-limit (402/429) aborts the theme rather than burning the loop
+  [`esg-news.ts:88`](../../pipeline/src/scraper/esg-news.ts#L88)
+- `sanitizeArticleText` retained as the defense-in-depth barrier
+  [`esg-news.ts:68`](../../pipeline/src/scraper/esg-news.ts#L68)
+- Missing-key throws once → orchestrator try/catch keeps the pipeline alive
+  [`esg-news.ts:104`](../../pipeline/src/scraper/esg-news.ts#L104)
+
+**Secret wiring (deploy-gate safety)**
+
+- Optional ARN — does not break the deployed pipeline before the secret exists
+  [`config.schema.ts:31`](../../pipeline/src/config.schema.ts#L31)
+- Conditional load, empty-string sentinel when unset
+  [`main.ts:34`](../../pipeline/src/main.ts#L34)
+- One-line call-site change in the orchestrator
+  [`orchestrator.ts:247`](../../pipeline/src/orchestrator.ts#L247)
+- `Secrets` type addition
+  [`types.ts:98`](../../pipeline/src/types.ts#L98)
+
+**Tests (peripherals)**
+
+- Client: request contract (v2 URL/Bearer/body), non-2xx, non-JSON, network error
+  [`firecrawl.helpers.spec.ts:1`](../../pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts#L1)
+- Scraper: all 8 I/O-matrix rows + cap + undated-skip + 402-abort, `fetch` mocked
+  [`esg-news.spec.ts:1`](../../pipeline/src/scraper/__tests__/esg-news.spec.ts#L1)

--- a/apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-esgnews-scraper.md
+++ b/apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-esgnews-scraper.md
@@ -9,6 +9,8 @@ context:
   - '{project-root}/apps/news-digest/_bmad-output/project-context.md'
 ---
 
+# Migrate ESG News scraper from Playwright to Firecrawl
+
 <frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
 
 ## Intent

--- a/apps/news-digest/pipeline/src/config.schema.ts
+++ b/apps/news-digest/pipeline/src/config.schema.ts
@@ -28,6 +28,7 @@ export const envSchema = z.object({
   NOTION_TOKEN_SECRET_ARN: z.string().min(1),
   GMAIL_SECRET_ARN: z.string().min(1),
   PROXY_SECRET_ARN: z.string().min(1),
+  FIRECRAWL_API_KEY_SECRET_ARN: z.string().optional(),
   SLACK_CHANNEL_ID: z.string().default('C0ADBQGHMDH'),
   NOTION_DATABASE_ID: z.string().default('2a09703d-8e9c-8193-b638-f7bb6b1c7cd8'),
   GMAIL_TO: z.string().default('market-intelligence@carrot.eco'),

--- a/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  FirecrawlError,
+  firecrawlScrape,
+  firecrawlSearch,
+} from '../firecrawl.helpers.js';
+
+function mockFetch(response: { ok: boolean; status?: number; body?: unknown }): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: response.ok,
+      status: response.status ?? (response.ok ? 200 : 500),
+      json: async () => response.body ?? {},
+    })),
+  );
+}
+
+describe('firecrawlSearch', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('maps data.web entries to {url,title} and drops incomplete ones', async () => {
+    mockFetch({
+      ok: true,
+      body: {
+        data: {
+          web: [
+            { url: 'https://esgnews.com/a/', title: ' Article A ' },
+            { url: 'https://esgnews.com/b/' }, // missing title -> dropped
+            { title: 'No URL' }, // missing url -> dropped
+          ],
+        },
+      },
+    });
+
+    const results = await firecrawlSearch('methane', 'fc-key');
+
+    expect(results).toEqual([{ url: 'https://esgnews.com/a/', title: 'Article A' }]);
+  });
+
+  it('POSTs to the v2 search endpoint with bearer auth and a JSON body', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { web: [] } }),
+    }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await firecrawlSearch('methane', 'fc-key', 5);
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('https://api.firecrawl.dev/v2/search');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer fc-key');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(JSON.parse(init.body)).toEqual({
+      query: 'methane',
+      limit: 5,
+      sources: [{ type: 'web' }],
+    });
+  });
+
+  it('throws FirecrawlError without an API key (no network call)', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await expect(firecrawlSearch('methane', '')).rejects.toBeInstanceOf(FirecrawlError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws FirecrawlError with the status on a non-2xx response', async () => {
+    mockFetch({ ok: false, status: 429 });
+    await expect(firecrawlSearch('methane', 'fc-key')).rejects.toMatchObject({
+      name: 'FirecrawlError',
+      status: 429,
+    });
+  });
+});
+
+describe('firecrawlScrape', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns markdown plus published time and author from metadata', async () => {
+    mockFetch({
+      ok: true,
+      body: {
+        data: {
+          markdown: '# Title\n\nBody text.',
+          metadata: {
+            'article:published_time': '2026-05-10T08:00:00Z',
+            author: 'Jane Doe',
+          },
+        },
+      },
+    });
+
+    const result = await firecrawlScrape('https://esgnews.com/a/', 'fc-key');
+
+    expect(result).toEqual({
+      markdown: '# Title\n\nBody text.',
+      publishedTime: '2026-05-10T08:00:00Z',
+      author: 'Jane Doe',
+    });
+  });
+
+  it('coerces array-valued metadata and falls back to article:author', async () => {
+    mockFetch({
+      ok: true,
+      body: {
+        data: {
+          markdown: 'Body.',
+          metadata: {
+            'article:published_time': ['2026-05-10T08:00:00Z'],
+            'article:author': 'Fallback Author',
+          },
+        },
+      },
+    });
+
+    const result = await firecrawlScrape('https://esgnews.com/a/', 'fc-key');
+
+    expect(result.publishedTime).toBe('2026-05-10T08:00:00Z');
+    expect(result.author).toBe('Fallback Author');
+  });
+
+  it('throws FirecrawlError on a non-2xx response', async () => {
+    mockFetch({ ok: false, status: 500 });
+    await expect(firecrawlScrape('https://esgnews.com/a/', 'fc-key')).rejects.toBeInstanceOf(
+      FirecrawlError,
+    );
+  });
+
+  it('wraps a non-JSON 200 body in a FirecrawlError (not a raw SyntaxError)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token < in JSON');
+        },
+      })),
+    );
+    await expect(firecrawlScrape('https://esgnews.com/a/', 'fc-key')).rejects.toMatchObject({
+      name: 'FirecrawlError',
+      status: 200,
+    });
+  });
+
+  it('wraps a fetch network error in a FirecrawlError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('socket hang up');
+      }),
+    );
+    await expect(firecrawlScrape('https://esgnews.com/a/', 'fc-key')).rejects.toBeInstanceOf(
+      FirecrawlError,
+    );
+  });
+});

--- a/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
@@ -1,0 +1,134 @@
+// Thin Firecrawl v2 HTTP client (search + scrape) used by the scrapers.
+//
+// Firecrawl replaces hand-written CSS-selector scraping: `search` gives
+// layout-resilient discovery and `scrape` returns markdown regardless of DOM.
+// Mirrors the raw-`fetch` pattern in `ai/article-processor.ts` (no SDK).
+// Validated against the v2 API in the 2026-05-18 Step 0 spike.
+
+const FIRECRAWL_API_BASE = 'https://api.firecrawl.dev/v2';
+const SCRAPE_TIMEOUT_MS = 60_000;
+const SEARCH_TIMEOUT_MS = 30_000;
+// Client-side ceiling above the server-side `timeout` hint so a hung socket
+// can't block the scheduled pipeline indefinitely (orchestrator try/catch
+// catches errors, not hangs).
+const CLIENT_TIMEOUT_BUFFER_MS = 15_000;
+
+export class FirecrawlError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'FirecrawlError';
+    this.status = status;
+  }
+}
+
+export interface FirecrawlSearchResult {
+  readonly url: string;
+  readonly title: string;
+}
+
+export interface FirecrawlScrapeResult {
+  readonly markdown: string;
+  readonly publishedTime: string;
+  readonly author: string;
+}
+
+function firstString(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
+  return '';
+}
+
+async function firecrawlPost(
+  path: string,
+  apiKey: string,
+  body: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<Record<string, unknown>> {
+  if (!apiKey) {
+    throw new FirecrawlError('FIRECRAWL_API_KEY not configured');
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${FIRECRAWL_API_BASE}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error: unknown) {
+    const reason = error instanceof Error ? error.message : 'network error';
+    throw new FirecrawlError(`Firecrawl ${path} request failed: ${reason}`);
+  }
+
+  if (!response.ok) {
+    throw new FirecrawlError(`Firecrawl ${path} returned ${response.status}`, response.status);
+  }
+
+  try {
+    return (await response.json()) as Record<string, unknown>;
+  } catch {
+    throw new FirecrawlError(`Firecrawl ${path} returned a non-JSON body`, response.status);
+  }
+}
+
+/**
+ * Web search via Firecrawl. Returns `{ url, title }` for each web result,
+ * dropping entries missing either field.
+ */
+export async function firecrawlSearch(
+  query: string,
+  apiKey: string,
+  limit = 10,
+): Promise<FirecrawlSearchResult[]> {
+  const data = await firecrawlPost(
+    '/search',
+    apiKey,
+    { query, limit, sources: [{ type: 'web' }] },
+    SEARCH_TIMEOUT_MS + CLIENT_TIMEOUT_BUFFER_MS,
+  );
+
+  const payload = (data['data'] ?? {}) as Record<string, unknown>;
+  const web = Array.isArray(payload['web']) ? payload['web'] : [];
+
+  return web
+    .map((entry): FirecrawlSearchResult => {
+      const record = (entry ?? {}) as Record<string, unknown>;
+      return {
+        url: typeof record['url'] === 'string' ? record['url'] : '',
+        title: typeof record['title'] === 'string' ? record['title'].trim() : '',
+      };
+    })
+    .filter((result) => result.url.length > 0 && result.title.length > 0);
+}
+
+/**
+ * Scrape a single URL to markdown (main content only). Pull publish time and
+ * author from page metadata when present.
+ */
+export async function firecrawlScrape(
+  url: string,
+  apiKey: string,
+): Promise<FirecrawlScrapeResult> {
+  const data = await firecrawlPost(
+    '/scrape',
+    apiKey,
+    { url, formats: ['markdown'], onlyMainContent: true, timeout: SCRAPE_TIMEOUT_MS },
+    SCRAPE_TIMEOUT_MS + CLIENT_TIMEOUT_BUFFER_MS,
+  );
+
+  const payload = (data['data'] ?? {}) as Record<string, unknown>;
+  const metadata = (payload['metadata'] ?? {}) as Record<string, unknown>;
+
+  return {
+    markdown: typeof payload['markdown'] === 'string' ? payload['markdown'] : '',
+    publishedTime: firstString(metadata['article:published_time']),
+    author:
+      firstString(metadata['author']) || firstString(metadata['article:author']),
+  };
+}

--- a/apps/news-digest/pipeline/src/main.ts
+++ b/apps/news-digest/pipeline/src/main.ts
@@ -29,11 +29,18 @@ async function loadSecrets(
   const gmailParsed = gmailSecretSchema.parse(JSON.parse(gmailRaw));
   const proxyParsed = proxySecretSchema.parse(JSON.parse(proxyRaw));
 
+  // Optional — not yet provisioned in every environment. Empty string when the
+  // ARN is unset; consumers (ESG News scraper) fail gracefully on empty key.
+  const firecrawlApiKey = env.FIRECRAWL_API_KEY_SECRET_ARN
+    ? await getSecret(client, env.FIRECRAWL_API_KEY_SECRET_ARN)
+    : '';
+
   return {
     carbonPulse: cpParsed,
     proxy: proxyParsed,
     slackToken,
     anthropicApiKey: apiKey,
+    firecrawlApiKey,
     notionToken,
     gmail: {
       clientId: gmailParsed.client_id,

--- a/apps/news-digest/pipeline/src/orchestrator.ts
+++ b/apps/news-digest/pipeline/src/orchestrator.ts
@@ -244,7 +244,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     console.log('Step 4: Scraping ESG News...');
     try {
       const cpTitles = cpArticles.map((a) => a.title);
-      esgArticles = await scrapeEsgNews(eligibleThemes, processedUrls, cpTitles);
+      esgArticles = await scrapeEsgNews(eligibleThemes, processedUrls, cpTitles, config.secrets.firecrawlApiKey);
       console.log(`ESG News: ${esgArticles.length} articles`);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : 'unknown';

--- a/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
@@ -304,6 +304,60 @@ describe('scrapeEsgNews', () => {
     expect(result[0]!.mainTheme).toBe('Fine');
   });
 
+  it('fills the per-theme cap from later candidates when early ones are skipped', async () => {
+    installFetch({
+      search: () => [
+        { url: 'https://esgnews.com/undated/', title: 'Undated' },
+        { url: 'https://esgnews.com/stale/', title: 'Stale' },
+        { url: 'https://esgnews.com/good1/', title: 'Good 1' },
+        { url: 'https://esgnews.com/good2/', title: 'Good 2' },
+      ],
+      scrape: {
+        'https://esgnews.com/undated/': { markdown: 'Valid body but no date.', publishedTime: '' },
+        'https://esgnews.com/stale/': {
+          markdown: 'Valid body but ancient.',
+          publishedTime: daysAgoIso(120),
+        },
+        'https://esgnews.com/good1/': {
+          markdown: 'Fresh article one about carbon markets and policy.',
+          publishedTime: daysAgoIso(1),
+        },
+        'https://esgnews.com/good2/': {
+          markdown: 'Fresh article two about composting infrastructure.',
+          publishedTime: daysAgoIso(2),
+        },
+      },
+    });
+
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+
+    expect(result.map((article) => article.url)).toEqual([
+      'https://esgnews.com/good1/',
+      'https://esgnews.com/good2/',
+    ]);
+  });
+
+  it('preserves articles already collected when a later scrape hits a quota error', async () => {
+    installFetch({
+      search: () => [
+        { url: 'https://esgnews.com/collected/', title: 'Collected' },
+        { url: 'https://esgnews.com/quota/', title: 'Quota' },
+      ],
+      scrape: {
+        'https://esgnews.com/collected/': {
+          markdown: 'A solid article body about methane monitoring.',
+          publishedTime: daysAgoIso(1),
+        },
+        'https://esgnews.com/quota/': { status: 402 },
+      },
+    });
+
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('https://esgnews.com/collected/');
+  });
+
   it('throws when the Firecrawl API key is not configured', async () => {
     await expect(scrapeEsgNews([stubTheme()], new Set(), [], '')).rejects.toThrow(
       /FIRECRAWL_API_KEY not configured/,

--- a/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
@@ -1,16 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { ThemeConfig } from '../../types.js';
-
-vi.mock('playwright', () => ({
-  chromium: {
-    launch: vi.fn(),
-  },
-}));
-
-import { chromium } from 'playwright';
 import { scrapeEsgNews } from '../esg-news.js';
 
-const TODAY_ISO = new Date().toISOString().slice(0, 10);
+const KEY = 'fc-test-key';
 
 function stubTheme(overrides: Partial<ThemeConfig> = {}): ThemeConfig {
   return {
@@ -23,62 +15,298 @@ function stubTheme(overrides: Partial<ThemeConfig> = {}): ThemeConfig {
   };
 }
 
-function mockBrowser(evaluations: Array<() => unknown>) {
-  const evalQueue = [...evaluations];
-  const page = {
-    goto: vi.fn(async () => null),
-    evaluate: vi.fn(async () => {
-      const current = evalQueue.shift();
-      return current ? current() : null;
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+type ScrapeEntry =
+  | { markdown: string; publishedTime?: string; author?: string }
+  | { status: number };
+
+function installFetch(opts: {
+  search: (query: string) => Array<{ url: string; title: string }>;
+  scrape: Record<string, ScrapeEntry>;
+}): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init: { body: string }) => {
+      const body = JSON.parse(init.body) as { query?: string; url?: string };
+      if (url.endsWith('/v2/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: { web: opts.search(body.query ?? '') } }),
+        };
+      }
+      const entry = opts.scrape[body.url ?? ''];
+      if (!entry || 'status' in entry) {
+        return { ok: false, status: entry ? entry.status : 404, json: async () => ({}) };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            markdown: entry.markdown,
+            metadata: {
+              'article:published_time': entry.publishedTime ?? daysAgoIso(2),
+              author: entry.author ?? '',
+            },
+          },
+        }),
+      };
     }),
-  };
-  const browser = {
-    newPage: vi.fn(async () => page),
-    close: vi.fn(async () => undefined),
-  };
-  vi.mocked(chromium.launch).mockResolvedValue(browser as never);
-  return { browser, page };
+  );
 }
 
 describe('scrapeEsgNews', () => {
-  afterEach(() => vi.clearAllMocks());
-
-  it('sanitizes scraped page chrome out of fullContent (regression: 2026-05-18 broken ESG articles)', async () => {
-    mockBrowser([
-      // Search results page: one article link.
-      () => [{ url: 'https://esgnews.com/nz/', title: 'NZ Climate Law' }],
-      // Article page: textContent of <article> leaked all the page chrome.
-      () => ({
-        content:
-          'Climate\n/\nGovernment\n/\nNews\nby ESG News Editorial Team\n' +
-          'Share:\nShare on Facebook\nShare on Twitter\nShare on LinkedIn\n' +
-          '<img loading="lazy" src="https://esgnews.com/nz.webp" srcset="https://esgnews.com/nz.webp 780w" />\n' +
-          'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.\n' +
-          'RELATED ARTICLE: New Zealand Lifts Climate Reporting Thresholds\n' +
-          'Subscribe & Follow for Daily ESG Insights\n' +
-          'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran journalists.',
-        author: 'ESG News Editorial Team',
-        date: TODAY_ISO,
-      }),
-    ]);
-
-    const result = await scrapeEsgNews([stubTheme()], new Set(), []);
-
-    expect(result).toHaveLength(1);
-    const body = result[0]?.fullContent ?? '';
-    expect(body).not.toContain('<img');
-    expect(body).not.toContain('srcset');
-    expect(body).not.toMatch(/Share on (Facebook|Twitter|LinkedIn)/);
-    expect(body).not.toMatch(/RELATED ARTICLE:/);
-    expect(body).not.toMatch(/Subscribe & Follow/);
-    expect(body).not.toMatch(/Editorial Team is comprised of/);
-    expect(body).toContain('New Zealand plans to amend the Climate Change Response Act 2002 to block claims.');
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
   });
 
-  it('closes the browser in a finally block even when scraping throws', async () => {
-    const { browser } = mockBrowser([]);
-    browser.newPage.mockRejectedValueOnce(new Error('page creation failed'));
-    await expect(scrapeEsgNews([stubTheme()], new Set(), [])).rejects.toThrow('page creation failed');
-    expect(browser.close).toHaveBeenCalled();
+  it('returns a sanitized RawArticle and strips page chrome from markdown', async () => {
+    installFetch({
+      search: () => [{ url: 'https://esgnews.com/nz/', title: 'NZ Climate Law' }],
+      scrape: {
+        'https://esgnews.com/nz/': {
+          markdown:
+            'Climate\n/\nGovernment\n/\nNews\nby ESG News Editorial Team\n' +
+            'Share:\nShare on Facebook\nShare on LinkedIn\n' +
+            'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.\n' +
+            'RELATED ARTICLE: New Zealand Lifts Climate Reporting Thresholds\n' +
+            'Subscribe & Follow for Daily ESG Insights\n' +
+            'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran journalists.',
+          author: 'ESG News Editorial Team',
+          publishedTime: daysAgoIso(3),
+        },
+      },
+    });
+
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+
+    expect(result).toHaveLength(1);
+    const article = result[0]!;
+    expect(article.source).toBe('esgnews');
+    expect(article.url).toBe('https://esgnews.com/nz/');
+    expect(article.author).toBe('ESG News Editorial Team');
+    expect(article.fullContent).toContain(
+      'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.',
+    );
+    expect(article.fullContent).not.toMatch(/Share on (Facebook|LinkedIn)/);
+    expect(article.fullContent).not.toMatch(/RELATED ARTICLE:/);
+    expect(article.fullContent).not.toMatch(/Subscribe & Follow/);
+    expect(article.fullContent).not.toMatch(/Editorial Team is comprised of/);
+  });
+
+  it('skips results already in processedUrls (no scrape call)', async () => {
+    installFetch({
+      search: () => [{ url: 'https://esgnews.com/seen/', title: 'Seen Article' }],
+      scrape: {},
+    });
+    const result = await scrapeEsgNews(
+      [stubTheme()],
+      new Set(['https://esgnews.com/seen/']),
+      [],
+      KEY,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips results that duplicate a Carbon Pulse title', async () => {
+    installFetch({
+      search: () => [
+        { url: 'https://esgnews.com/dup/', title: 'Global Methane Pledge Reaches Milestone' },
+      ],
+      scrape: {},
+    });
+    const result = await scrapeEsgNews(
+      [stubTheme()],
+      new Set(),
+      ['Global Methane Pledge Reaches Major Milestone Today'],
+      KEY,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips articles older than the age limit', async () => {
+    installFetch({
+      search: () => [{ url: 'https://esgnews.com/old/', title: 'Old Article' }],
+      scrape: {
+        'https://esgnews.com/old/': {
+          markdown: 'This is a sufficiently long article body about carbon markets.',
+          publishedTime: daysAgoIso(120),
+        },
+      },
+    });
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips pages that sanitize to empty (chrome-only)', async () => {
+    installFetch({
+      search: () => [{ url: 'https://esgnews.com/chrome/', title: 'Chrome Only' }],
+      scrape: {
+        'https://esgnews.com/chrome/': {
+          markdown: 'Share:\nShare on Facebook\nSubscribe & Follow\nRELATED ARTICLE: Something',
+          publishedTime: daysAgoIso(1),
+        },
+      },
+    });
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    expect(result).toHaveLength(0);
+  });
+
+  it('continues other themes when one theme search fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { query?: string; url?: string };
+        if (url.endsWith('/v2/search')) {
+          if ((body.query ?? '').includes('boom')) {
+            return { ok: false, status: 500, json: async () => ({}) };
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: { web: [{ url: 'https://esgnews.com/ok/', title: 'Good One' }] },
+            }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              markdown: 'A solid article body about composting infrastructure and policy.',
+              metadata: { 'article:published_time': daysAgoIso(2), author: 'ESG News' },
+            },
+          }),
+        };
+      }),
+    );
+
+    const result = await scrapeEsgNews(
+      [stubTheme({ name: 'Bad', esgNewsSearchTerms: 'boom' }), stubTheme({ name: 'Good' })],
+      new Set(),
+      [],
+      KEY,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.mainTheme).toBe('Good');
+  });
+
+  it('skips a single article whose scrape fails but keeps the others', async () => {
+    installFetch({
+      search: () => [
+        { url: 'https://esgnews.com/bad/', title: 'Bad Scrape' },
+        { url: 'https://esgnews.com/good/', title: 'Good Scrape' },
+      ],
+      scrape: {
+        'https://esgnews.com/bad/': { status: 500 },
+        'https://esgnews.com/good/': {
+          markdown: 'A complete article body discussing carbon market regulation in depth.',
+          publishedTime: daysAgoIso(1),
+        },
+      },
+    });
+
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('https://esgnews.com/good/');
+  });
+
+  it('skips an article with no parseable publish date (parity with carbon-pulse)', async () => {
+    installFetch({
+      search: () => [{ url: 'https://esgnews.com/undated/', title: 'Undated' }],
+      scrape: {
+        'https://esgnews.com/undated/': {
+          markdown: 'A perfectly valid long article body with no date metadata.',
+          publishedTime: '',
+        },
+      },
+    });
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    expect(result).toHaveLength(0);
+  });
+
+  it('scrapes at most MAX_ARTICLES_PER_THEME eligible results', async () => {
+    let scrapeCalls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        if (url.endsWith('/v2/search')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: {
+                web: [
+                  { url: 'https://esgnews.com/1/', title: 'One' },
+                  { url: 'https://esgnews.com/2/', title: 'Two' },
+                  { url: 'https://esgnews.com/3/', title: 'Three' },
+                ],
+              },
+            }),
+          };
+        }
+        scrapeCalls += 1;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              markdown: `Body for ${body.url} with enough prose to survive sanitization.`,
+              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
+            },
+          }),
+        };
+      }),
+    );
+
+    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+
+    expect(scrapeCalls).toBe(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('aborts the theme on a quota error (402) without burning the rest of the loop', async () => {
+    installFetch({
+      search: (query) =>
+        query.includes('quota')
+          ? [
+              { url: 'https://esgnews.com/q1/', title: 'Q1' },
+              { url: 'https://esgnews.com/q2/', title: 'Q2' },
+            ]
+          : [{ url: 'https://esgnews.com/ok/', title: 'OK' }],
+      scrape: {
+        'https://esgnews.com/q1/': { status: 402 },
+        'https://esgnews.com/q2/': { status: 402 },
+        'https://esgnews.com/ok/': {
+          markdown: 'A healthy article body about carbon market regulation.',
+          publishedTime: daysAgoIso(1),
+        },
+      },
+    });
+
+    const result = await scrapeEsgNews(
+      [stubTheme({ name: 'Quota', esgNewsSearchTerms: 'quota' }), stubTheme({ name: 'Fine' })],
+      new Set(),
+      [],
+      KEY,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.mainTheme).toBe('Fine');
+  });
+
+  it('throws when the Firecrawl API key is not configured', async () => {
+    await expect(scrapeEsgNews([stubTheme()], new Set(), [], '')).rejects.toThrow(
+      /FIRECRAWL_API_KEY not configured/,
+    );
   });
 });

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -1,93 +1,95 @@
-import { chromium } from 'playwright';
-import type { Browser, Page } from 'playwright';
 import { sanitizeArticleText } from '../helpers/content.helpers.js';
+import { FirecrawlError, firecrawlScrape, firecrawlSearch } from '../helpers/firecrawl.helpers.js';
 import type { RawArticle, ThemeConfig } from '../types.js';
 
-const SEARCH_URL = 'https://esgnews.com/?s=';
 const MAX_ARTICLES_PER_THEME = 2;
 const MAX_ARTICLE_AGE_DAYS = 30;
+const SEARCH_LIMIT = 10;
 
-async function extractArticleContent(page: Page): Promise<{
-  content: string;
-  author: string;
-  date: string;
-}> {
-  return page.evaluate(() => {
-    const article = document.querySelector('article') ?? document.body;
-    const content = article.textContent?.trim() ?? '';
-    const timeEl = document.querySelector('time');
-    const date = timeEl?.getAttribute('datetime')?.slice(0, 10) ?? '';
-    const authorEl = document.querySelector('.author, .byline, [rel="author"]');
-    const author = authorEl?.textContent?.trim() ?? 'ESG News';
-    return { content, author, date };
+function parseDate(raw: string): string {
+  if (!raw) return '';
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return parsed.toISOString().slice(0, 10);
+}
+
+function isDuplicateOfCarbonPulse(title: string, cpTitles: readonly string[]): boolean {
+  const lowerTitle = title.toLowerCase();
+  return cpTitles.some((cpTitle) => {
+    const cpWords = new Set(
+      cpTitle.toLowerCase().split(/\s+/).filter((word) => word.length > 3),
+    );
+    const esgWords = lowerTitle.split(/\s+/).filter((word) => word.length > 3);
+    const overlap = esgWords.filter((word) => cpWords.has(word)).length;
+    return cpWords.size > 0 && overlap / cpWords.size >= 0.5;
   });
 }
 
 async function searchAndExtract(
-  page: Page,
   theme: ThemeConfig,
   processedUrls: ReadonlySet<string>,
   cpTitles: readonly string[],
+  apiKey: string,
 ): Promise<RawArticle[]> {
-  const searchUrl = `${SEARCH_URL}${encodeURIComponent(theme.esgNewsSearchTerms)}`;
-  await page.goto(searchUrl, { waitUntil: 'domcontentloaded' });
-  const links = await page.evaluate(() => {
-    const results = document.querySelectorAll('article a, h2 a, h3 a');
-    const seen = new Set<string>();
-    return Array.from(results)
-      .filter((a) => {
-        const href = (a as HTMLAnchorElement).href;
-        if (seen.has(href) || !href.includes('esgnews.com')) return false;
-        seen.add(href);
-        return true;
-      })
-      .map((a) => ({
-        url: (a as HTMLAnchorElement).href,
-        title: a.textContent?.trim() ?? '',
-      }));
+  const results = await firecrawlSearch(
+    `site:esgnews.com ${theme.esgNewsSearchTerms}`,
+    apiKey,
+    SEARCH_LIMIT,
+  );
+
+  const seen = new Set<string>();
+  const candidates = results.filter((result) => {
+    if (!result.url.includes('esgnews.com')) return false;
+    if (processedUrls.has(result.url) || seen.has(result.url)) return false;
+    if (isDuplicateOfCarbonPulse(result.title, cpTitles)) return false;
+    seen.add(result.url);
+    return true;
   });
+
   const articles: RawArticle[] = [];
-  const candidates = links.filter((l) => !processedUrls.has(l.url));
-  for (const link of candidates.slice(0, MAX_ARTICLES_PER_THEME)) {
-    const lowerTitle = link.title.toLowerCase();
-    const isDupOfCp = cpTitles.some((cpTitle) => {
-      const cpWords = new Set(cpTitle.toLowerCase().split(/\s+/).filter((w) => w.length > 3));
-      const esgWords = lowerTitle.split(/\s+/).filter((w) => w.length > 3);
-      const overlap = esgWords.filter((w) => cpWords.has(w)).length;
-      return cpWords.size > 0 && overlap / cpWords.size >= 0.5;
-    });
-    if (isDupOfCp) continue;
+  for (const candidate of candidates.slice(0, MAX_ARTICLES_PER_THEME)) {
     try {
-      await page.goto(link.url, { waitUntil: 'domcontentloaded' });
-      const extracted = await extractArticleContent(page);
-      const articleDate = extracted.date || new Date().toISOString().slice(0, 10);
-      const ageMs = Date.now() - new Date(articleDate).getTime();
-      if (ageMs > MAX_ARTICLE_AGE_DAYS * 24 * 60 * 60 * 1000) {
-        console.warn(`[ESG News] Article too old (${articleDate}), skipping: ${link.url}`);
+      const scraped = await firecrawlScrape(candidate.url, apiKey);
+      // No reliable publish date — skip rather than stamp it "today" and let a
+      // stale article bypass the freshness window (parity with carbon-pulse.ts).
+      const articleDate = parseDate(scraped.publishedTime);
+      if (!articleDate) {
+        console.warn(`[ESG News] Missing/invalid publish date, skipping: ${candidate.url}`);
         continue;
       }
-      // esgnews.com wraps breadcrumbs, share buttons, <noscript> <img> markup,
-      // newsletter signup and the editorial-team bio inside <article>, so the
-      // raw textContent is full of chrome. Strip it at the source.
-      const cleanContent = sanitizeArticleText(extracted.content);
+      const ageMs = Date.now() - new Date(articleDate).getTime();
+      if (ageMs > MAX_ARTICLE_AGE_DAYS * 24 * 60 * 60 * 1000) {
+        console.warn(`[ESG News] Article too old (${articleDate}), skipping: ${candidate.url}`);
+        continue;
+      }
+      // Firecrawl markdown still carries breadcrumbs, share buttons, newsletter
+      // signup and the editorial-team bio (spike Robustness #7). Strip it at the
+      // source — the same defense-in-depth barrier used for every scraper.
+      const cleanContent = sanitizeArticleText(scraped.markdown);
       if (!cleanContent) {
-        console.warn(`[ESG News] No article body after sanitization, skipping: ${link.url}`);
+        console.warn(`[ESG News] No article body after sanitization, skipping: ${candidate.url}`);
         continue;
       }
       articles.push({
         source: 'esgnews',
-        url: link.url,
-        title: link.title,
+        url: candidate.url,
+        title: candidate.title,
         date: articleDate,
-        author: extracted.author,
+        author: scraped.author || 'ESG News',
         mainTheme: theme.name,
         categories: '',
         location: '',
         fullContent: cleanContent,
       });
     } catch (error: unknown) {
+      // Quota (402) / rate-limit (429) are fatal to the whole theme — every
+      // remaining candidate would hit the same wall. Propagate so the
+      // per-theme handler logs it instead of silently burning the loop.
+      if (error instanceof FirecrawlError && (error.status === 402 || error.status === 429)) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : 'unknown';
-      console.error(`Failed to extract ESG News article "${link.title}": ${message}`);
+      console.error(`Failed to extract ESG News article "${candidate.title}": ${message}`);
     }
   }
   return articles;
@@ -97,19 +99,23 @@ export async function scrapeEsgNews(
   themes: readonly ThemeConfig[],
   processedUrls: ReadonlySet<string>,
   cpTitles: readonly string[],
+  firecrawlApiKey: string,
 ): Promise<RawArticle[]> {
-  const browser = await chromium.launch({ headless: true });
-  try {
-    const page = await browser.newPage();
-    const allArticles: RawArticle[] = [];
-    for (const theme of themes) {
-      console.log(`[ESG News] Searching: ${theme.name}`);
-      const articles = await searchAndExtract(page, theme, processedUrls, cpTitles);
+  if (!firecrawlApiKey) {
+    throw new Error('FIRECRAWL_API_KEY not configured — ESG News scraping skipped');
+  }
+
+  const allArticles: RawArticle[] = [];
+  for (const theme of themes) {
+    console.log(`[ESG News] Searching: ${theme.name}`);
+    try {
+      const articles = await searchAndExtract(theme, processedUrls, cpTitles, firecrawlApiKey);
       allArticles.push(...articles);
       console.log(`[ESG News] Found ${articles.length} articles for ${theme.name}`);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'unknown';
+      console.error(`[ESG News] Search failed for "${theme.name}": ${message}`);
     }
-    return allArticles;
-  } finally {
-    await browser.close();
   }
+  return allArticles;
 }

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -39,15 +39,24 @@ async function searchAndExtract(
 
   const seen = new Set<string>();
   const candidates = results.filter((result) => {
-    if (!result.url.includes('esgnews.com')) return false;
+    let hostname = '';
+    try {
+      hostname = new URL(result.url).hostname.toLowerCase();
+    } catch {
+      return false;
+    }
+    if (hostname !== 'esgnews.com' && !hostname.endsWith('.esgnews.com')) return false;
     if (processedUrls.has(result.url) || seen.has(result.url)) return false;
     if (isDuplicateOfCarbonPulse(result.title, cpTitles)) return false;
     seen.add(result.url);
     return true;
   });
 
+  // Cap on *successful* extractions, not raw candidates: early candidates can
+  // be stale/empty/dup, so slicing up front would yield fewer than possible.
   const articles: RawArticle[] = [];
-  for (const candidate of candidates.slice(0, MAX_ARTICLES_PER_THEME)) {
+  for (const candidate of candidates) {
+    if (articles.length >= MAX_ARTICLES_PER_THEME) break;
     try {
       const scraped = await firecrawlScrape(candidate.url, apiKey);
       // No reliable publish date — skip rather than stamp it "today" and let a
@@ -82,11 +91,14 @@ async function searchAndExtract(
         fullContent: cleanContent,
       });
     } catch (error: unknown) {
-      // Quota (402) / rate-limit (429) are fatal to the whole theme — every
-      // remaining candidate would hit the same wall. Propagate so the
-      // per-theme handler logs it instead of silently burning the loop.
+      // Quota (402) / rate-limit (429): every remaining candidate would hit the
+      // same wall. Stop scraping this theme but KEEP what was already collected
+      // — throwing here would discard the partial `articles` for this theme.
       if (error instanceof FirecrawlError && (error.status === 402 || error.status === 429)) {
-        throw error;
+        console.error(
+          `[ESG News] Firecrawl ${error.status} (quota/rate limit) — aborting theme, keeping ${articles.length} collected`,
+        );
+        break;
       }
       const message = error instanceof Error ? error.message : 'unknown';
       console.error(`Failed to extract ESG News article "${candidate.title}": ${message}`);

--- a/apps/news-digest/pipeline/src/types.ts
+++ b/apps/news-digest/pipeline/src/types.ts
@@ -95,6 +95,7 @@ export interface Secrets {
   readonly proxy: ProxyConfig;
   readonly slackToken: string;
   readonly anthropicApiKey: string;
+  readonly firecrawlApiKey: string;
   readonly notionToken: string;
   readonly gmail: {
     readonly clientId: string;

--- a/cspell.json
+++ b/cspell.json
@@ -41,7 +41,8 @@
     "lorien",
     "dedups",
     "lede",
-    "ledes"
+    "ledes",
+    "jaccard"
   ],
   "dictionaries": [
     "companies",


### PR DESCRIPTION
### Summary

Migrates the **ESG News** scraper (~43% of digest volume) from Playwright + hand-written CSS selectors to the Firecrawl v2 HTTP API: `search` for layout-resilient discovery + `scrape` (markdown) for content, keeping `sanitizeArticleText` as the defense-in-depth barrier. First increment of the O3 plan from the BMAD brainstorm. Carbon Pulse, Substack and Trellis are intentionally untouched.

### Details

- **New `firecrawl.helpers.ts`** — minimal v2 `fetch` client (`firecrawlSearch`/`firecrawlScrape`) mirroring the `ai/article-processor.ts` pattern. Client-side `AbortSignal` timeout, typed `FirecrawlError` (carries `status`), non-JSON/network errors wrapped.
- **`esg-news.ts` rewritten** — same `RawArticle` contract and orchestrator resilience. Preserves `processedUrls`/CP-dup/age filters and the empty-after-sanitize skip. Undated articles are skipped (parity with `carbon-pulse.ts`); quota/rate-limit (402/429) aborts the theme instead of burning the loop.
- **Optional secret wiring** — `FIRECRAWL_API_KEY_SECRET_ARN` is optional in `envSchema`; absent ⇒ ESG News fails gracefully (orchestrator try/catch), the rest of the pipeline is unaffected. Deploy-gate safe.
- Built via the BMAD quick-dev flow: approved spec → implement → 3-agent adversarial review (no spec loopback) → 8 review patches → present. Spec, brainstorm and Step 0 spike reports are included under `apps/news-digest/_bmad-output/` with a Suggested Review Order in the spec.

**Verification:** `npx vitest run` → 152/152 passed (17 files, `fetch` mocked, no real network); `pnpm nx build news-digest-pipeline` → success.

**Reviewer notes:**
- **Not deployable yet (by design):** the `news-digest/firecrawl-api-key` secret + the Terraform/infra ARN are a separate prerequisite. Optional env keeps the deployed pipeline working until then.
- `pnpm nx lint news-digest-pipeline` is **not runnable in this environment** (pre-existing nx `@nx/linter:eslint` resolution failure; eslint also ignores these paths). Conventions followed manually.
- The brainstorm + spike docs also appear in PR #30; included here so this PR's spec context is self-contained. Identical content — no-op when either merges.
- `isDuplicateOfCarbonPulse` heuristic weakness (pre-existing) logged in `apps/news-digest/_bmad-output/implementation-artifacts/deferred-work.md`.

### Related links

- BMAD spec: `apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-esgnews-scraper.md`
- Docs PR: #30

---

- [ ] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces a high-volume scraper with a new external API integration and changes failure/skip behavior (missing dates, quota/rate-limit handling), though guarded by optional secret wiring and extensive mocked tests.
> 
> **Overview**
> **ESG News scraping is migrated from Playwright to Firecrawl v2.** The scraper now discovers articles via Firecrawl `search` and extracts markdown via `scrape`, while retaining existing sanitization/dedup/age/processed-url filters and adding stricter handling for *missing/invalid publish dates* (skip instead of defaulting to today).
> 
> **Adds Firecrawl client + secret plumbing and resilience behavior.** Introduces `firecrawl.helpers.ts` (typed `FirecrawlError`, timeouts, non-2xx/non-JSON/network wrapping), wires an *optional* `FIRECRAWL_API_KEY_SECRET_ARN` into `loadSecrets`/`Secrets`, and updates the orchestrator call site; ESG News scraping now aborts a theme on 402/429 while keeping already-collected articles.
> 
> **Tests are rewritten/added to mock `fetch` instead of Playwright.** New helper tests cover request/response mapping and error wrapping, and ESG News tests cover the main skip/error matrix including quota abort and per-theme caps. (Also adds BMAD spec/deferred-work docs and a `cspell` word.)
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72abe6fc68e3c5b6fd2a83c4b97eb916c2bfcd1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->