### PR TITLE
Wire optional FIRECRAWL_API_KEY secret into news-digest infra

### DIFF
--- a/apps/news-digest/infra/src/ecs.tf
+++ b/apps/news-digest/infra/src/ecs.tf
@@ -37,6 +37,7 @@ resource "aws_ecs_task_definition" "pipeline" {
       { name = "NOTION_TOKEN_SECRET_ARN", value = aws_secretsmanager_secret.notion_token.arn },
       { name = "GMAIL_SECRET_ARN", value = aws_secretsmanager_secret.gmail_credentials.arn },
       { name = "PROXY_SECRET_ARN", value = aws_secretsmanager_secret.proxy.arn },
+      { name = "FIRECRAWL_API_KEY_SECRET_ARN", value = aws_secretsmanager_secret.firecrawl_api_key.arn },
     ]
 
     logConfiguration = {

--- a/apps/news-digest/infra/src/iam.tf
+++ b/apps/news-digest/infra/src/iam.tf
@@ -55,6 +55,7 @@ resource "aws_iam_role_policy" "ecs_task" {
           aws_secretsmanager_secret.notion_token.arn,
           aws_secretsmanager_secret.gmail_credentials.arn,
           aws_secretsmanager_secret.proxy.arn,
+          aws_secretsmanager_secret.firecrawl_api_key.arn,
         ]
       },
       {

--- a/apps/news-digest/infra/src/secrets.tf
+++ b/apps/news-digest/infra/src/secrets.tf
@@ -33,3 +33,9 @@ resource "aws_secretsmanager_secret" "proxy" {
   description = "Residential proxy credentials for Cloudflare bypass"
   tags        = { Name = "${var.app_name}/proxy", Purpose = "Proxy for web scraping" }
 }
+
+resource "aws_secretsmanager_secret" "firecrawl_api_key" {
+  name        = "${var.app_name}/firecrawl-api-key"
+  description = "Firecrawl API key (raw fc- token) for ESG News / Trellis scraping"
+  tags        = { Name = "${var.app_name}/firecrawl-api-key", Purpose = "Firecrawl scraping auth" }
+}


### PR DESCRIPTION
### Summary

Wires the optional `FIRECRAWL_API_KEY` secret into the news-digest ECS infra so the merged ESG News (#31) and Trellis (#32) Firecrawl scrapers can actually run. Infra-only — no pipeline code.

### Details

- `secrets.tf` — new `news-digest/firecrawl-api-key` Secrets Manager **container** (value set out-of-band via `aws secretsmanager put-secret-value`, exactly like the other secrets — no value in Terraform).
- `iam.tf` — ECS task role granted `secretsmanager:GetSecretValue` on the new secret ARN.
- `ecs.tf` — `FIRECRAWL_API_KEY_SECRET_ARN` added to the task-definition environment.

The pipeline env is **optional**: until the secret value is populated, `scrapeEsgNews`/`scrapeTrellis` throw and are caught by the orchestrator (ESG/Trellis yield 0, pipeline keeps running). So `terraform apply` here is safe and does not change behaviour until (a) the secret value is set and (b) the ECR image is rebuilt with the Firecrawl code.

### Deploy / validation sequence (must complete before relying on it)

1. Merge + `terraform apply` (creates the secret container + wiring; prod unaffected — still runs the old image).
2. Populate the secret value with a real Firecrawl API key (`aws secretsmanager put-secret-value`).
3. Isolated ECS validation run (throwaway S3 key + `DRY_RUN`, non-`:latest` image tag) → confirm ESG + Trellis return real articles, measure Firecrawl credit burn vs the 1000/mo + 2-concurrent free tier.
4. Only then rebuild/push `:latest` so the scheduled run uses Firecrawl.

Reviewer note: pre-existing `terraform fmt` drift in `iam.tf` was intentionally left out of this PR (separate cleanup) to keep the diff to the 3 functional lines.

### Related links

- ESG News scraper: #31 (merged) · Trellis scraper: #32 (open)

---

- [ ] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk infra-only change that adds a new Secrets Manager resource and grants the ECS task permission to read it; main risk is a deploy/runtime failure if consumers assume the secret is populated.
> 
> **Overview**
> Adds a new AWS Secrets Manager secret container for a Firecrawl API key (`news-digest/firecrawl-api-key`) and wires it into the `news-digest` ECS task definition via `FIRECRAWL_API_KEY_SECRET_ARN`.
> 
> Updates the ECS task IAM policy to allow `secretsmanager:GetSecretValue` on the new secret ARN so the running task can retrieve it at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b98a5f3325bcdbec557b8d33d60e76619be514f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->