### PR TITLE
fix(news-digest): bias firecrawl /search to recent results via tbs

### DIFF
--- a/apps/news-digest/pipeline/src/config.schema.ts
+++ b/apps/news-digest/pipeline/src/config.schema.ts
@@ -36,6 +36,10 @@ export const envSchema = z.object({
   SKIP_SLACK: z.string().default('false'),
   SKIP_EMAIL: z.string().default('false'),
   SKIP_NOTION: z.string().default('false'),
+  // Comma-separated theme names. When set, restricts processing to those
+  // themes only (applied AFTER getEligibleThemes). Knob for cheap one-theme
+  // validation runs — see helpers/theme.helpers parseThemesFilter.
+  THEMES_FILTER: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
@@ -63,6 +63,25 @@ describe('firecrawlSearch', () => {
     });
   });
 
+  it('includes the tbs time filter in the body when provided (recency bias)', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { web: [] } }),
+    }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await firecrawlSearch('methane', 'fc-key', 5, 'qdr:m');
+
+    const [, init] = fetchSpy.mock.calls[0]!;
+    expect(JSON.parse(init.body)).toEqual({
+      query: 'methane',
+      limit: 5,
+      sources: [{ type: 'web' }],
+      tbs: 'qdr:m',
+    });
+  });
+
   it('throws FirecrawlError without an API key (no network call)', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);

--- a/apps/news-digest/pipeline/src/helpers/__tests__/theme.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/theme.helpers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getEligibleThemes } from '../theme.helpers.js';
+import { applyThemesFilter, getEligibleThemes, parseThemesFilter } from '../theme.helpers.js';
 import { THEMES } from '../../config.constants.js';
 
 describe('getEligibleThemes', () => {
@@ -38,5 +38,52 @@ describe('getEligibleThemes', () => {
   it('returns weekly theme when never processed before', () => {
     const result = getEligibleThemes(THEMES, {}, today);
     expect(result.find((t) => t.name === 'Carbon Markets')).toBeDefined();
+  });
+});
+
+describe('parseThemesFilter', () => {
+  it('returns undefined for unset / empty input', () => {
+    expect(parseThemesFilter(undefined)).toBeUndefined();
+    expect(parseThemesFilter('')).toBeUndefined();
+    expect(parseThemesFilter('   ')).toBeUndefined();
+    expect(parseThemesFilter(',, ,')).toBeUndefined();
+  });
+
+  it('parses a comma-separated list, trimming whitespace', () => {
+    expect(parseThemesFilter('Carrot Mentions')).toEqual(new Set(['Carrot Mentions']));
+    expect(parseThemesFilter('Carrot Mentions, Carbon Markets')).toEqual(
+      new Set(['Carrot Mentions', 'Carbon Markets']),
+    );
+    expect(parseThemesFilter('  Carrot Mentions  ,  Carbon Markets  ')).toEqual(
+      new Set(['Carrot Mentions', 'Carbon Markets']),
+    );
+  });
+
+  it('drops empty entries from a malformed list', () => {
+    expect(parseThemesFilter('Carrot Mentions,,Carbon Markets,')).toEqual(
+      new Set(['Carrot Mentions', 'Carbon Markets']),
+    );
+  });
+});
+
+describe('applyThemesFilter', () => {
+  it('returns the input unchanged when no filter is provided', () => {
+    const result = applyThemesFilter(THEMES, undefined);
+    expect(result).toEqual([...THEMES]);
+  });
+
+  it('keeps only themes whose name is in the allowlist', () => {
+    const result = applyThemesFilter(THEMES, new Set(['Carrot Mentions']));
+    expect(result.map((theme) => theme.name)).toEqual(['Carrot Mentions']);
+  });
+
+  it('ignores unknown names without erroring', () => {
+    const result = applyThemesFilter(THEMES, new Set(['Not A Real Theme', 'Carbon Markets']));
+    expect(result.map((theme) => theme.name)).toEqual(['Carbon Markets']);
+  });
+
+  it('returns empty when the allowlist matches no themes', () => {
+    const result = applyThemesFilter(THEMES, new Set(['Nothing Matches']));
+    expect(result).toEqual([]);
   });
 });

--- a/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
@@ -80,17 +80,27 @@ async function firecrawlPost(
 
 /**
  * Web search via Firecrawl. Returns `{ url, title }` for each web result,
- * dropping entries missing either field.
+ * dropping entries missing either field. Pass `tbs` (e.g. `'qdr:m'` for past
+ * month) to bias results toward recency — without it the search returns
+ * mostly evergreen/stale pages that the per-scraper freshness filter then
+ * rejects, gutting recall (verified in the 2026-05-19 isolated ECS run).
  */
 export async function firecrawlSearch(
   query: string,
   apiKey: string,
   limit = 10,
+  tbs?: string,
 ): Promise<FirecrawlSearchResult[]> {
+  const body: Record<string, unknown> = {
+    query,
+    limit,
+    sources: [{ type: 'web' }],
+  };
+  if (tbs) body['tbs'] = tbs;
   const data = await firecrawlPost(
     '/search',
     apiKey,
-    { query, limit, sources: [{ type: 'web' }] },
+    body,
     SEARCH_TIMEOUT_MS + CLIENT_TIMEOUT_BUFFER_MS,
   );
 

--- a/apps/news-digest/pipeline/src/helpers/theme.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/theme.helpers.ts
@@ -22,3 +22,31 @@ export function getEligibleThemes(
     return daysSince >= minDays;
   });
 }
+
+/**
+ * Parse the comma-separated `THEMES_FILTER` env var into a normalized set of
+ * theme names. Whitespace around each name is trimmed; empty entries dropped.
+ * Returns `undefined` when the input is unset/blank, signalling "no filter".
+ *
+ * Operational knob for cheap one-theme validation runs — `daily` themes are
+ * unconditionally eligible (`minDays === 0` in `getEligibleThemes`), so state
+ * pre-seeding alone cannot drop below 5 themes.
+ */
+export function parseThemesFilter(raw: string | undefined): Set<string> | undefined {
+  if (!raw) return undefined;
+  const names = raw.split(',').map((name) => name.trim()).filter((name) => name.length > 0);
+  if (names.length === 0) return undefined;
+  return new Set(names);
+}
+
+/**
+ * Restrict `themes` to those whose name appears in `allowed`. When `allowed`
+ * is `undefined` the input list is returned unchanged (no filter active).
+ */
+export function applyThemesFilter(
+  themes: readonly ThemeConfig[],
+  allowed: ReadonlySet<string> | undefined,
+): ThemeConfig[] {
+  if (!allowed) return [...themes];
+  return themes.filter((theme) => allowed.has(theme.name));
+}

--- a/apps/news-digest/pipeline/src/main.ts
+++ b/apps/news-digest/pipeline/src/main.ts
@@ -4,6 +4,7 @@ import {
 } from '@aws-sdk/client-secrets-manager';
 import { envSchema, carbonPulseSecretSchema, gmailSecretSchema, proxySecretSchema } from './config.schema.js';
 import { runPipeline } from './orchestrator.js';
+import { parseThemesFilter } from './helpers/theme.helpers.js';
 import type { Secrets } from './types.js';
 
 async function getSecret(client: SecretsManagerClient, arn: string): Promise<string> {
@@ -62,11 +63,13 @@ async function main(): Promise<void> {
   const skipSlack = env.SKIP_SLACK === 'true';
   const skipEmail = env.SKIP_EMAIL === 'true';
   const skipNotion = env.SKIP_NOTION === 'true';
+  const themesFilter = parseThemesFilter(env.THEMES_FILTER);
 
   if (dryRun) console.log('[DRY RUN] Distribution (Notion, email, Slack) disabled.');
   if (skipSlack) console.log('[CONFIG] Slack distribution disabled via SKIP_SLACK.');
   if (skipEmail) console.log('[CONFIG] Email distribution disabled via SKIP_EMAIL.');
   if (skipNotion) console.log('[CONFIG] Notion distribution disabled via SKIP_NOTION.');
+  if (themesFilter) console.log(`[CONFIG] THEMES_FILTER active: ${[...themesFilter].join(', ')}`);
 
   const result = await runPipeline({
     secrets,
@@ -81,6 +84,7 @@ async function main(): Promise<void> {
     skipSlack,
     skipEmail,
     skipNotion,
+    themesFilter,
   });
 
   const duration = ((Date.now() - startTime) / 1000).toFixed(1);

--- a/apps/news-digest/pipeline/src/orchestrator.ts
+++ b/apps/news-digest/pipeline/src/orchestrator.ts
@@ -1,5 +1,5 @@
 import { S3Store } from './state/s3-store.js';
-import { getEligibleThemes } from './helpers/theme.helpers.js';
+import { applyThemesFilter, getEligibleThemes } from './helpers/theme.helpers.js';
 import { deduplicateArticles } from './helpers/dedup.helpers.js';
 import { buildArticleMarkdown, slugify } from './helpers/markdown.helpers.js';
 import { scrapeCarbonPulse } from './scraper/carbon-pulse.js';
@@ -27,6 +27,10 @@ interface PipelineConfig {
   readonly skipSlack: boolean;
   readonly skipEmail: boolean;
   readonly skipNotion: boolean;
+  // Allowlist of theme names. When set, the eligible-themes list is further
+  // restricted to these names — knob for cheap one-theme validation runs
+  // since `daily` themes are otherwise unconditionally eligible.
+  readonly themesFilter?: ReadonlySet<string>;
 }
 
 const AI_CONCURRENCY = 5;
@@ -218,7 +222,13 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
 
   // Step 2: Determine eligible themes
   console.log('Step 2: Determining eligible themes...');
-  const eligibleThemes = getEligibleThemes(THEMES, state.themeLastProcessed, today);
+  const rotationEligible = getEligibleThemes(THEMES, state.themeLastProcessed, today);
+  const eligibleThemes = applyThemesFilter(rotationEligible, config.themesFilter);
+  if (config.themesFilter) {
+    console.log(
+      `[THEMES_FILTER] Restricting to ${eligibleThemes.length} of ${rotationEligible.length} rotation-eligible themes`,
+    );
+  }
   console.log(`Eligible themes: ${eligibleThemes.map((t) => t.name).join(', ')}`);
 
   if (eligibleThemes.length === 0) {

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -6,6 +6,10 @@ import type { RawArticle, ThemeConfig } from '../types.js';
 const MAX_ARTICLES_PER_THEME = 2;
 const MAX_ARTICLE_AGE_DAYS = 30;
 const SEARCH_LIMIT = 10;
+// Past-month — matches MAX_ARTICLE_AGE_DAYS. Without `tbs` Firecrawl returns
+// mostly evergreen/stale pages; the freshness filter then drops ~97% of them
+// (122/138 "too old" in the 2026-05-19 validation run).
+const SEARCH_RECENCY = 'qdr:m';
 
 function isDuplicateOfCarbonPulse(title: string, cpTitles: readonly string[]): boolean {
   const lowerTitle = title.toLowerCase();
@@ -29,6 +33,7 @@ async function searchAndExtract(
     `site:esgnews.com ${theme.esgNewsSearchTerms}`,
     apiKey,
     SEARCH_LIMIT,
+    SEARCH_RECENCY,
   );
 
   const seen = new Set<string>();

--- a/apps/news-digest/pipeline/src/scraper/trellis.ts
+++ b/apps/news-digest/pipeline/src/scraper/trellis.ts
@@ -10,6 +10,10 @@ const MAX_ARTICLE_AGE_DAYS = 30;
 const CANDIDATE_POOL_SIZE = 15;
 const SEARCH_LIMIT = 10;
 const MAX_EXCERPT_LENGTH = 400;
+// Past-month — matches MAX_ARTICLE_AGE_DAYS. See firecrawl.helpers `tbs` doc;
+// recency-bias is required because Firecrawl /search otherwise returns mostly
+// evergreen pages (2026-05-19 validation: 122/138 ESG candidates "too old").
+const SEARCH_RECENCY = 'qdr:m';
 // The curator (not a per-theme query) decides which of these are worth the
 // digest; keep the discovery query broad and recency-biased, scoped to Trellis.
 const CURATION_QUERY = 'site:trellis.net climate sustainability decarbonization circular economy';
@@ -92,6 +96,7 @@ async function searchTheme(
     `site:trellis.net ${theme.trellisSearchTerms}`,
     apiKey,
     SEARCH_LIMIT,
+    SEARCH_RECENCY,
   );
 
   const seen = new Set<string>();
@@ -129,7 +134,7 @@ async function collectCandidates(
 ): Promise<TrellisCandidate[]> {
   // Over-request: host/exclude/dedup filtering below would otherwise shrink the
   // pool below CANDIDATE_POOL_SIZE with no top-up.
-  const results = await firecrawlSearch(CURATION_QUERY, apiKey, CANDIDATE_POOL_SIZE * 2);
+  const results = await firecrawlSearch(CURATION_QUERY, apiKey, CANDIDATE_POOL_SIZE * 2, SEARCH_RECENCY);
   const seen = new Set<string>();
   const candidates: TrellisCandidate[] = [];
   for (const result of results) {


### PR DESCRIPTION
### Summary

Pass `tbs="qdr:m"` (past-month) on every Firecrawl `/search` call so the discovery layer surfaces fresh articles instead of evergreen/stale pages.

### Details

The 2026-05-19 isolated ECS validation run (task `2d7890c77d…`, 16 themes, `DRY_RUN=true`, throwaway S3 prefix) showed that Firecrawl `/search` returns mostly old pages by default:

- ESG News yielded **4 articles** across 16 themes; **122/138 candidates dropped as "Article too old"** (>30d by `MAX_ARTICLE_AGE_DAYS`).
- Trellis yielded **3 articles** across 16 themes.
- Prod baseline (S3 `processed-articles.json` 30-day window) averaged ~5 ESG + ~1 Trellis per *daily-only* incremental run, so this would be a clear recall regression vs the old Playwright scrapers.

Root cause: the old scrapers got recency for free by reading each site's date-sorted listing page; Firecrawl web search does not replicate that unless `tbs` is set. Firecrawl v2 supports the Google-style `tbs` parameter (`qdr:h|d|w|m|y` or `cdr:1,cd_min,cd_max`); `qdr:m` matches `MAX_ARTICLE_AGE_DAYS=30` in both scrapers.

Implementation:

- `firecrawl.helpers.ts` — new optional `tbs?: string` param on `firecrawlSearch`; only injected into the request body when provided (backward-compatible).
- `esg-news.ts` — `SEARCH_RECENCY = "qdr:m"` constant, passed on the per-theme search.
- `trellis.ts` — `SEARCH_RECENCY = "qdr:m"` constant, passed on both call sites (per-theme search + curation candidate pool).
- New Vitest case covering `tbs` injection; existing tests stay green via the optional-arg path.

Validation: 166 tests pass locally. Infrastructure / IAM / image / S3 isolation already verified by the prior validation run — only the discovery recency was the regression. A lean re-validation (5 daily themes, pre-seeded throwaway state) is queued post-merge.

### Related links

- Validation memory: `apps/news-digest/_bmad-output` + Personal memory under `news-digest-firecrawl-decision`
- Firecrawl docs: https://docs.firecrawl.dev → Search → Time-Based Search (`tbs`)
- Previous PRs: #31 (ESG), #32 (Trellis), #33 (infra)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes discovery inputs (Firecrawl `/search` now optionally adds `tbs` and scrapers pass `qdr:m`), which can materially shift article selection/volume; also adds an env-driven theme allowlist that can unexpectedly filter out all themes if misconfigured.
> 
> **Overview**
> Improves Firecrawl-based discovery by adding an optional `tbs` parameter to `firecrawlSearch` and using it in ESG News and Trellis searches (`qdr:m`) to bias results toward recent pages.
> 
> Adds an operational `THEMES_FILTER` env var to restrict the pipeline to an allowlisted set of theme names, wiring this through `main.ts` → `runPipeline` and applying it after rotation eligibility.
> 
> Extends Vitest coverage for both the new Firecrawl request shape (`tbs` injection) and the theme-filter parsing/application helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea83e3df91aa802b867674c928687d94cd83ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->