### PR TITLE
fix(news-digest): drop tbs=qdr:m from firecrawl /search (kills recall)

### DIFF
--- a/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
@@ -63,25 +63,6 @@ describe('firecrawlSearch', () => {
     });
   });
 
-  it('includes the tbs time filter in the body when provided (recency bias)', async () => {
-    const fetchSpy = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ data: { web: [] } }),
-    }));
-    vi.stubGlobal('fetch', fetchSpy);
-
-    await firecrawlSearch('methane', 'fc-key', 5, 'qdr:m');
-
-    const [, init] = fetchSpy.mock.calls[0]!;
-    expect(JSON.parse(init.body)).toEqual({
-      query: 'methane',
-      limit: 5,
-      sources: [{ type: 'web' }],
-      tbs: 'qdr:m',
-    });
-  });
-
   it('throws FirecrawlError without an API key (no network call)', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);

--- a/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
@@ -80,27 +80,24 @@ async function firecrawlPost(
 
 /**
  * Web search via Firecrawl. Returns `{ url, title }` for each web result,
- * dropping entries missing either field. Pass `tbs` (e.g. `'qdr:m'` for past
- * month) to bias results toward recency — without it the search returns
- * mostly evergreen/stale pages that the per-scraper freshness filter then
- * rejects, gutting recall (verified in the 2026-05-19 isolated ECS run).
+ * dropping entries missing either field.
+ *
+ * Recency: the Google-style `tbs=qdr:*` filter was tried and dropped — for
+ * `site:esgnews.com` / `site:trellis.net` queries it excluded **all** results
+ * (Firecrawl honors `tbs` only when the underlying index has a clean
+ * publish date; both publishers lack one, so the filter is binary-fatal).
+ * A hybrid listing-page scrape will replace it; until then recency relies
+ * solely on the per-scraper `MAX_ARTICLE_AGE_DAYS` filter.
  */
 export async function firecrawlSearch(
   query: string,
   apiKey: string,
   limit = 10,
-  tbs?: string,
 ): Promise<FirecrawlSearchResult[]> {
-  const body: Record<string, unknown> = {
-    query,
-    limit,
-    sources: [{ type: 'web' }],
-  };
-  if (tbs) body['tbs'] = tbs;
   const data = await firecrawlPost(
     '/search',
     apiKey,
-    body,
+    { query, limit, sources: [{ type: 'web' }] },
     SEARCH_TIMEOUT_MS + CLIENT_TIMEOUT_BUFFER_MS,
   );
 

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -6,10 +6,6 @@ import type { RawArticle, ThemeConfig } from '../types.js';
 const MAX_ARTICLES_PER_THEME = 2;
 const MAX_ARTICLE_AGE_DAYS = 30;
 const SEARCH_LIMIT = 10;
-// Past-month — matches MAX_ARTICLE_AGE_DAYS. Without `tbs` Firecrawl returns
-// mostly evergreen/stale pages; the freshness filter then drops ~97% of them
-// (122/138 "too old" in the 2026-05-19 validation run).
-const SEARCH_RECENCY = 'qdr:m';
 
 function isDuplicateOfCarbonPulse(title: string, cpTitles: readonly string[]): boolean {
   const lowerTitle = title.toLowerCase();
@@ -33,7 +29,6 @@ async function searchAndExtract(
     `site:esgnews.com ${theme.esgNewsSearchTerms}`,
     apiKey,
     SEARCH_LIMIT,
-    SEARCH_RECENCY,
   );
 
   const seen = new Set<string>();

--- a/apps/news-digest/pipeline/src/scraper/trellis.ts
+++ b/apps/news-digest/pipeline/src/scraper/trellis.ts
@@ -10,10 +10,6 @@ const MAX_ARTICLE_AGE_DAYS = 30;
 const CANDIDATE_POOL_SIZE = 15;
 const SEARCH_LIMIT = 10;
 const MAX_EXCERPT_LENGTH = 400;
-// Past-month — matches MAX_ARTICLE_AGE_DAYS. See firecrawl.helpers `tbs` doc;
-// recency-bias is required because Firecrawl /search otherwise returns mostly
-// evergreen pages (2026-05-19 validation: 122/138 ESG candidates "too old").
-const SEARCH_RECENCY = 'qdr:m';
 // The curator (not a per-theme query) decides which of these are worth the
 // digest; keep the discovery query broad and recency-biased, scoped to Trellis.
 const CURATION_QUERY = 'site:trellis.net climate sustainability decarbonization circular economy';
@@ -96,7 +92,6 @@ async function searchTheme(
     `site:trellis.net ${theme.trellisSearchTerms}`,
     apiKey,
     SEARCH_LIMIT,
-    SEARCH_RECENCY,
   );
 
   const seen = new Set<string>();
@@ -134,7 +129,7 @@ async function collectCandidates(
 ): Promise<TrellisCandidate[]> {
   // Over-request: host/exclude/dedup filtering below would otherwise shrink the
   // pool below CANDIDATE_POOL_SIZE with no top-up.
-  const results = await firecrawlSearch(CURATION_QUERY, apiKey, CANDIDATE_POOL_SIZE * 2, SEARCH_RECENCY);
+  const results = await firecrawlSearch(CURATION_QUERY, apiKey, CANDIDATE_POOL_SIZE * 2);
   const seen = new Set<string>();
   const candidates: TrellisCandidate[] = [];
   for (const result of results) {


### PR DESCRIPTION
### Summary

Reverts the `tbs=qdr:m` portion of PR #34. The Google-style time filter zeros out every result on the queries the scrapers actually run — opposite of intended. `THEMES_FILTER` (the other half of #34) is unaffected and remains.

### Details

After #34 merged we ran a 1-theme isolated validation (`THEMES_FILTER="Methane & Super Pollutants"`, ~15 cr) and got `Found 0 articles` from both ESG News and Trellis, with **no intermediate "Article too old" debris** — which suggested the API was returning nothing. Confirmed via direct A/B probe (~4 cr) on the Firecrawl `/v2/search` endpoint with the exact scraper queries:

| Query | without `tbs` | with `tbs=qdr:m` |
|---|---|---|
| `site:esgnews.com methane superpollutant` | **9 results** (all stale) | **0** |
| `site:trellis.net methane superpollutant refrigerant` | **10 results** | **0** |

Firecrawl honors `tbs` only when the underlying index has a clean publish date for the hit. `esgnews.com` and `trellis.net` permalinks do not expose machine-readable dates the upstream search index trusts, so `qdr:m` is binary-fatal — it removes every result instead of "stale ones".

The right recency mechanism is hybrid listing-page discovery (each publisher already serves a date-ordered listing) — a follow-up PR will implement that.

### What changes

- `firecrawl.helpers.ts` — drop the `tbs?: string` param; restore the original body literal. Helper comment documents the experiment so the next person does not retry the same dead end.
- `esg-news.ts` / `trellis.ts` — drop `SEARCH_RECENCY` constant; restore 3-arg `firecrawlSearch` calls (3 sites: 1 ESG, 2 Trellis).
- `firecrawl.helpers.spec.ts` — drop the `tbs`-body-injection test.

### What stays

- `THEMES_FILTER` env, `parseThemesFilter`, `applyThemesFilter` (all of `theme.helpers.ts` + tests + `config.schema.ts` + `main.ts` + `orchestrator.ts` plumbing). Knob works and is needed independent of search recency.

### Tests

172 pass (was 173 with the dropped `tbs` test).

### Production safety

Prod `:latest` was never rebuilt against #34 — production still runs the pre-#31 code. No rollback needed in infra; this PR just realigns the codebase before the hybrid-discovery PR lands.

### Related links

- PR #34 — added the now-reverted `tbs` (and the kept `THEMES_FILTER`)
- Validation logs / probe results documented under `news-digest-firecrawl-decision` memory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes discovery behavior for ESG News/Trellis by widening Firecrawl `/search` results, which may increase stale candidates and affect scraper throughput/credit usage, but is localized to search request construction and call sites.
> 
> **Overview**
> **Drops Firecrawl `/search` recency filtering.** `firecrawlSearch` no longer accepts/forwards a `tbs` parameter and always posts `{ query, limit, sources }`.
> 
> Updates the ESG News and Trellis scrapers to stop passing `SEARCH_RECENCY` (including the Trellis curation search), and removes the unit test that asserted `tbs` body injection; helper docs now explain why `tbs=qdr:*` was reverted and that recency relies on `MAX_ARTICLE_AGE_DAYS` for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd134bbe2aba0fca852ac2b4d24c08ea627c504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->