### PR TITLE
feat(news-digest): hybrid Firecrawl discovery via publisher search pages

### DIFF
--- a/apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-hybrid-discovery.md
+++ b/apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-hybrid-discovery.md
@@ -1,0 +1,136 @@
+# Spec — Hybrid discovery for Firecrawl scrapers (PR #36)
+
+**Date:** 2026-05-19
+**Author:** quick-dev session
+**Replaces:** Firecrawl `/search` discovery introduced in PRs #31 (ESG News) and #32 (Trellis).
+**Status:** Draft — awaiting approval
+
+## Problem
+
+The 2026-05-19 validation runs proved that **Firecrawl `/v2/search` cannot deliver recency** on the publishers we crawl:
+
+| Source | Mechanism | Recall (16-theme test, 30-day window) |
+|---|---|---|
+| Old Playwright (pre-PRs #31/#32) | navigate site's own `/?s=` page, extract links | prod baseline ~5 ESG + ~1 Trellis per *daily-only* run |
+| Firecrawl `/search` (PRs #31/#32) | Google-style web search | 4 ESG + 3 Trellis across **16 themes** (regression) |
+| Firecrawl `/search` + `tbs=qdr:m` (PR #34) | recency filter on the search | **0** results — `tbs` is binary-fatal when the upstream index lacks dates, which is exactly the case for `esgnews.com` / `trellis.net` (confirmed via direct API A/B, PR #35 reverted it) |
+
+Root cause of the regression: Firecrawl's `/search` proxies an external web index that does not have machine-readable publish dates for these publishers' permalinks. The old Playwright code never went through that index — it hit each site's own WordPress search page (default sort: date-desc) and read date-ordered links straight from the HTML.
+
+## Goal
+
+Restore the recency the old scrapers had **without bringing Playwright back**. Keep Firecrawl as the fetch layer (it still kills Cloudflare bypass + selector rot on article bodies, the original migration win). Replace only the discovery step.
+
+## Approach: hybrid listing-scrape
+
+For each publisher, **Firecrawl-`scrape` the publisher's own date-ordered listing/search page**, then parse article links out of the returned markdown.
+
+### ESG News
+
+- Per-theme discovery URL: `https://esgnews.com/?s=<URL-encoded theme.esgNewsSearchTerms>`
+- WordPress site search; default ordering is publish-date-desc
+- Extract markdown links pointing at `esgnews.com` permalinks (exclude tag/category/archive index pages — the same pattern that produced 16 "Missing/invalid publish date" entries before)
+- Per chosen candidate: `firecrawlScrape(articleUrl)` → existing freshness filter + `sanitizeArticleText`
+- `MAX_ARTICLES_PER_THEME = 2` (unchanged)
+
+### Trellis — per-theme
+
+- Per-theme discovery URL: `https://trellis.net/?s=<URL-encoded theme.trellisSearchTerms>`
+- WordPress site search, same recency property
+- Extract anchors matching `isTrellisArticleUrl` (in-domain + `/article/` path — unchanged)
+- Per chosen candidate: `firecrawlScrape(articleUrl)` → existing freshness + sanitize
+- `MAX_ARTICLES_PER_THEME = 1` (unchanged)
+
+### Trellis — curation pool
+
+- Broad pool discovery URL: `https://trellis.net/articles/` (the publisher's full articles index — same URL the old Playwright code used as `LISTING_URL`)
+- Single scrape per pipeline run (not per theme)
+- Extract `/article/` links; keep `CANDIDATE_POOL_SIZE * 2` over-request
+- `curateTrellisArticles` (unchanged), then per-pick `firecrawlScrape`
+
+## Helper to add
+
+`firecrawl.helpers.ts` — one new exported function:
+
+```ts
+export function extractMarkdownLinks(
+  markdown: string,
+  predicate: (link: { url: string; title: string }) => boolean,
+): Array<{ url: string; title: string }>
+```
+
+- Regex over standard markdown link syntax `[title](url)`
+- Trim title; drop empty titles
+- Apply `predicate` for host/path filtering (so each scraper keeps its own rules)
+- De-dupe by URL preserving first-seen order
+
+Kept narrow on purpose — link extraction is the only generic piece. Per-source predicates (host check, `/article/` path, exclude index pages) stay in the scrapers next to the rest of their domain logic.
+
+## What stays exactly as is
+
+- `firecrawlScrape` (article fetch) — already the right shape; this PR only changes discovery
+- `MAX_ARTICLE_AGE_DAYS = 30` freshness filter — still the safety net for any non-recent slip-through
+- `sanitizeArticleText` — defense-in-depth on the article body
+- Quota / 402 / 429 handling (`break`-keep-partial, `isQuotaError` in Trellis)
+- `seenUrls` cross-theme dedup
+- `isDuplicateOfCarbonPulse`
+- `parseDate` shared helper
+- `THEMES_FILTER` env + plumbing (PR #34, retained)
+- Substack RSS (no Firecrawl)
+- Carbon Pulse Playwright flow (still gated on the seat cap [[news-digest-carbonpulse-login-seatcap]])
+
+## What goes away
+
+- `firecrawlSearch` helper export (no remaining callers after this PR)
+- Its tests in `firecrawl.helpers.spec.ts`
+- The `/search`-result filter loop in `esg-news.ts` / `trellis.ts`
+
+## Cost model
+
+Per discovery: **1 scrape** (the listing page) — independent of how many candidates it yields. Per article kept: **1 scrape** (the article body). Compared to the `/search` path, the per-discovery cost is identical (1 cr) but recall is recovered.
+
+Projected with this design:
+
+| Scope | Listing scrapes | Article scrapes | ≈ credits |
+|---|---|---|---|
+| 1 theme | 2 (ESG + Trellis per-theme) + 1 (Trellis curation, shared) | ≤ 2 + ≤ 1 + curated picks (~3) | ~9–11 |
+| 5 daily | 5 ESG + 5 Trellis per-theme + 1 curation | ≤ 10 + ≤ 5 + ~5 curated | ~30–35 |
+| 16 themes | 16 + 16 + 1 | ≤ 32 + ≤ 16 + ~5 | ~85–100 |
+
+Comfortably inside the 1,000-cr/mo free tier even on prod's 16-theme worst case (~12 cr/day with rotation).
+
+## Risks and mitigations
+
+1. **WordPress `/?s=` returns "no results" HTML pages.** Markdown extraction would yield no `/article/` or `esgnews.com` permalink matches → empty candidate list → `Found 0` log line. Acceptable failure mode (mirrors current "no candidates" outcome) — no scrapes wasted.
+2. **Listing markdown carries menu / footer / pagination links.** The predicate-based filter (host + path pattern) handles this — same defense-in-depth as the post-scrape `sanitizeArticleText`.
+3. **WordPress search may need a brief JS render.** Firecrawl `/scrape` enables JS rendering by default; if a particular site needs explicit options we add them in the helper. Initial assumption: defaults suffice.
+4. **Trellis curation broad pool may return many candidates.** `CANDIDATE_POOL_SIZE * 2 = 30` cap stays; the curator decides which to scrape.
+5. **A listing scrape can transient-fail (502 like the validation run saw).** Catch + log + continue; same pattern as the article-scrape failure path already in both scrapers.
+
+## Out of scope
+
+- URL-date pre-filter (`/YYYY/MM/...` permalink pattern) — deferred; not needed if listings are date-ordered.
+- Schema-driven `/extract` — premium credits, not justified at current recall expectations.
+- Carbon Pulse migration — still gated on the subscription seat cap.
+
+## Tests (Vitest)
+
+- `firecrawl.helpers.spec.ts` — `extractMarkdownLinks`: standard markdown, empty input, no matches, dedup preserving order, predicate-based filtering, malformed markdown safety.
+- `esg-news.spec.ts` — mock `fetch` to return a listing-page markdown (real-ish: ~10 article links + menu noise), assert: only article permalinks reach scraping, `MAX_ARTICLES_PER_THEME` cap, freshness + sanitize integration, cross-theme `seenUrls` dedup, `isDuplicateOfCarbonPulse` exclusion.
+- `trellis.spec.ts` — same shape for the per-theme path + the curation broad-pool path; quota short-circuit; `isTrellisArticleUrl` filter; curator dedupe.
+- All previously green tests must remain green (172 → expected ~175+ post-PR).
+
+## Validation plan
+
+After merge:
+
+1. Rebuild `firecrawl-validation` image from new main.
+2. Run isolated ECS task with `THEMES_FILTER="Methane & Super Pollutants"` (`DRY_RUN=true`, throwaway S3 prefix as before).
+3. Inspect CloudWatch logs:
+   - Listing scrapes succeeded (no 502/404)?
+   - `extractMarkdownLinks` produced non-zero candidates?
+   - At least one of ESG/Trellis returns ≥ 1 article (the same theme returned 0 with both pre-`tbs` and `tbs` paths — non-zero now is the proof).
+4. Spot-check the article content (sanitization quality, dates).
+5. Only if green → rebuild `:latest` and ship.
+
+Expected cost of validation: ~9–11 cr.

--- a/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
+++ b/apps/news-digest/pipeline/src/helpers/__tests__/firecrawl.helpers.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   FirecrawlError,
+  extractMarkdownLinks,
   firecrawlScrape,
-  firecrawlSearch,
 } from '../firecrawl.helpers.js';
 
 function mockFetch(response: { ok: boolean; status?: number; body?: unknown }): void {
@@ -15,69 +15,6 @@ function mockFetch(response: { ok: boolean; status?: number; body?: unknown }): 
     })),
   );
 }
-
-describe('firecrawlSearch', () => {
-  afterEach(() => vi.unstubAllGlobals());
-
-  it('maps data.web entries to {url,title,description} and drops incomplete ones', async () => {
-    mockFetch({
-      ok: true,
-      body: {
-        data: {
-          web: [
-            { url: 'https://esgnews.com/a/', title: ' Article A ', description: ' Lead text ' },
-            { url: 'https://esgnews.com/b/' }, // missing title -> dropped
-            { title: 'No URL' }, // missing url -> dropped
-          ],
-        },
-      },
-    });
-
-    const results = await firecrawlSearch('methane', 'fc-key');
-
-    expect(results).toEqual([
-      { url: 'https://esgnews.com/a/', title: 'Article A', description: 'Lead text' },
-    ]);
-  });
-
-  it('POSTs to the v2 search endpoint with bearer auth and a JSON body', async () => {
-    const fetchSpy = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ data: { web: [] } }),
-    }));
-    vi.stubGlobal('fetch', fetchSpy);
-
-    await firecrawlSearch('methane', 'fc-key', 5);
-
-    const [url, init] = fetchSpy.mock.calls[0]!;
-    expect(url).toBe('https://api.firecrawl.dev/v2/search');
-    expect(init.method).toBe('POST');
-    expect(init.headers.Authorization).toBe('Bearer fc-key');
-    expect(init.headers['Content-Type']).toBe('application/json');
-    expect(init.signal).toBeInstanceOf(AbortSignal);
-    expect(JSON.parse(init.body)).toEqual({
-      query: 'methane',
-      limit: 5,
-      sources: [{ type: 'web' }],
-    });
-  });
-
-  it('throws FirecrawlError without an API key (no network call)', async () => {
-    const fetchSpy = vi.fn();
-    vi.stubGlobal('fetch', fetchSpy);
-    await expect(firecrawlSearch('methane', '')).rejects.toBeInstanceOf(FirecrawlError);
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it('throws FirecrawlError with the status on a non-2xx response', async () => {
-    mockFetch({ ok: false, status: 429 });
-    await expect(firecrawlSearch('methane', 'fc-key')).rejects.toMatchObject({
-      name: 'FirecrawlError',
-      status: 429,
-    });
-  });
-});
 
 describe('firecrawlScrape', () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -125,11 +62,43 @@ describe('firecrawlScrape', () => {
     expect(result.author).toBe('Fallback Author');
   });
 
-  it('throws FirecrawlError on a non-2xx response', async () => {
-    mockFetch({ ok: false, status: 500 });
-    await expect(firecrawlScrape('https://esgnews.com/a/', 'fc-key')).rejects.toBeInstanceOf(
+  it('POSTs to the v2 scrape endpoint with bearer auth and a JSON body', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { markdown: '', metadata: {} } }),
+    }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await firecrawlScrape('https://esgnews.com/a/', 'fc-key');
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('https://api.firecrawl.dev/v2/scrape');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer fc-key');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    const body = JSON.parse(init.body) as Record<string, unknown>;
+    expect(body['url']).toBe('https://esgnews.com/a/');
+    expect(body['formats']).toEqual(['markdown']);
+    expect(body['onlyMainContent']).toBe(true);
+  });
+
+  it('throws FirecrawlError without an API key (no network call)', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await expect(firecrawlScrape('https://esgnews.com/a/', '')).rejects.toBeInstanceOf(
       FirecrawlError,
     );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws FirecrawlError with the status on a non-2xx response', async () => {
+    mockFetch({ ok: false, status: 429 });
+    await expect(firecrawlScrape('https://esgnews.com/a/', 'fc-key')).rejects.toMatchObject({
+      name: 'FirecrawlError',
+      status: 429,
+    });
   });
 
   it('wraps a non-JSON 200 body in a FirecrawlError (not a raw SyntaxError)', async () => {
@@ -159,5 +128,106 @@ describe('firecrawlScrape', () => {
     await expect(firecrawlScrape('https://esgnews.com/a/', 'fc-key')).rejects.toBeInstanceOf(
       FirecrawlError,
     );
+  });
+});
+
+describe('extractMarkdownLinks', () => {
+  const acceptAll = (): boolean => true;
+
+  it('extracts inline links in source order', () => {
+    const md = 'See [One](https://a.example/x) and [Two](https://b.example/y) and [Three](https://c.example/z).';
+    expect(extractMarkdownLinks(md, acceptAll)).toEqual([
+      { url: 'https://a.example/x', title: 'One' },
+      { url: 'https://b.example/y', title: 'Two' },
+      { url: 'https://c.example/z', title: 'Three' },
+    ]);
+  });
+
+  it('returns an empty array for empty or matchless input', () => {
+    expect(extractMarkdownLinks('', acceptAll)).toEqual([]);
+    expect(extractMarkdownLinks('no markdown here', acceptAll)).toEqual([]);
+  });
+
+  it('trims surrounding whitespace from the title', () => {
+    expect(extractMarkdownLinks('[  Spaces  ](https://a/x)', acceptAll)).toEqual([
+      { url: 'https://a/x', title: 'Spaces' },
+    ]);
+  });
+
+  it('drops links with empty title or empty url', () => {
+    const md = '[Good](https://a/x) [](https://b/y) [No URL]()';
+    expect(extractMarkdownLinks(md, acceptAll)).toEqual([
+      { url: 'https://a/x', title: 'Good' },
+    ]);
+  });
+
+  it('deduplicates by url preserving first occurrence', () => {
+    const md = '[First](https://a/x) [Second](https://a/x) [Third](https://b/y)';
+    expect(extractMarkdownLinks(md, acceptAll)).toEqual([
+      { url: 'https://a/x', title: 'First' },
+      { url: 'https://b/y', title: 'Third' },
+    ]);
+  });
+
+  it('supports inline links with a "title" attribute', () => {
+    expect(
+      extractMarkdownLinks('[Doc](https://a/x "Tooltip")', acceptAll),
+    ).toEqual([{ url: 'https://a/x', title: 'Doc' }]);
+  });
+
+  it('filters out entries the predicate rejects', () => {
+    const md = '[Keep](https://a/keep) [Drop](https://a/drop)';
+    const onlyKeep = ({ url }: { url: string }): boolean => url.endsWith('/keep');
+    expect(extractMarkdownLinks(md, onlyKeep)).toEqual([
+      { url: 'https://a/keep', title: 'Keep' },
+    ]);
+  });
+
+  it('predicate sees title alongside url (for content-aware filters)', () => {
+    const md = '[Climate change rule](https://a/1) [Sponsored: buy now](https://a/2)';
+    const noAds = ({ title }: { title: string }): boolean => !title.startsWith('Sponsored');
+    expect(extractMarkdownLinks(md, noAds)).toEqual([
+      { url: 'https://a/1', title: 'Climate change rule' },
+    ]);
+  });
+
+  it('ignores reference-style links and bare urls', () => {
+    const md = '[Ref][1]\n\n[1]: https://a/x\n\nhttps://a/y bare';
+    expect(extractMarkdownLinks(md, acceptAll)).toEqual([]);
+  });
+
+  it('rejects markdown image syntax (![alt](url)) to avoid scraping thumbnails', () => {
+    // Listing cards often include both a hero image and a text link to the
+    // same article; without this guard the helper would emit the JPG URL
+    // first and we'd waste a Firecrawl scrape on it before the cap caught up.
+    const md = '![Hero](https://a/cover.jpg) and [Real article](https://a/article-slug/)';
+    expect(extractMarkdownLinks(md, acceptAll)).toEqual([
+      { url: 'https://a/article-slug/', title: 'Real article' },
+    ]);
+  });
+});
+
+describe('FirecrawlError', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('preserves the underlying error as `cause` so outage detection has the original class', async () => {
+    const original = new Error('socket hang up');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw original;
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await firecrawlScrape('https://esgnews.com/a/', 'fc-key');
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(FirecrawlError);
+    expect((caught as FirecrawlError).cause).toBe(original);
+    expect((caught as FirecrawlError).status).toBeUndefined();
   });
 });

--- a/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
@@ -1,13 +1,22 @@
-// Thin Firecrawl v2 HTTP client (search + scrape) used by the scrapers.
+// Thin Firecrawl v2 HTTP client (scrape) used by the scrapers.
 //
-// Firecrawl replaces hand-written CSS-selector scraping: `search` gives
-// layout-resilient discovery and `scrape` returns markdown regardless of DOM.
+// Firecrawl replaces hand-written CSS-selector scraping: `scrape` returns
+// markdown regardless of DOM, and we discover article candidates by
+// scraping each publisher's own date-ordered listing/search page and
+// extracting links from that markdown.
+//
+// Why not `/v2/search`? It was tried (PRs #31/#32) and failed: the upstream
+// web index does not carry reliable publish dates for `esgnews.com` /
+// `trellis.net`, so its `tbs=qdr:*` recency filter is binary-fatal (PR #34
+// → reverted in #35). Hitting each publisher's own search/listing page
+// gives the same recency the old Playwright scrapers had for free.
+//
 // Mirrors the raw-`fetch` pattern in `ai/article-processor.ts` (no SDK).
-// Validated against the v2 API in the 2026-05-18 Step 0 spike.
+// Validated against the v2 API in the 2026-05-18 Step 0 spike and the
+// 2026-05-19 isolated ECS validation runs.
 
 const FIRECRAWL_API_BASE = 'https://api.firecrawl.dev/v2';
 const SCRAPE_TIMEOUT_MS = 60_000;
-const SEARCH_TIMEOUT_MS = 30_000;
 // Client-side ceiling above the server-side `timeout` hint so a hung socket
 // can't block the scheduled pipeline indefinitely (orchestrator try/catch
 // catches errors, not hangs).
@@ -15,24 +24,29 @@ const CLIENT_TIMEOUT_BUFFER_MS = 15_000;
 
 export class FirecrawlError extends Error {
   readonly status?: number;
+  // Preserve the underlying error class (AbortError, TypeError, …) so
+  // callers can distinguish a transport-level timeout from a quota
+  // response if they need to. Logged callers see `error.message`; outage
+  // detection can inspect `error.cause` instead of string-matching.
+  readonly cause?: unknown;
 
-  constructor(message: string, status?: number) {
+  constructor(message: string, status?: number, cause?: unknown) {
     super(message);
     this.name = 'FirecrawlError';
     this.status = status;
+    this.cause = cause;
   }
-}
-
-export interface FirecrawlSearchResult {
-  readonly url: string;
-  readonly title: string;
-  readonly description: string;
 }
 
 export interface FirecrawlScrapeResult {
   readonly markdown: string;
   readonly publishedTime: string;
   readonly author: string;
+}
+
+export interface MarkdownLink {
+  readonly url: string;
+  readonly title: string;
 }
 
 function firstString(value: unknown): string {
@@ -64,7 +78,7 @@ async function firecrawlPost(
     });
   } catch (error: unknown) {
     const reason = error instanceof Error ? error.message : 'network error';
-    throw new FirecrawlError(`Firecrawl ${path} request failed: ${reason}`);
+    throw new FirecrawlError(`Firecrawl ${path} request failed: ${reason}`, undefined, error);
   }
 
   if (!response.ok) {
@@ -79,47 +93,9 @@ async function firecrawlPost(
 }
 
 /**
- * Web search via Firecrawl. Returns `{ url, title }` for each web result,
- * dropping entries missing either field.
- *
- * Recency: the Google-style `tbs=qdr:*` filter was tried and dropped — for
- * `site:esgnews.com` / `site:trellis.net` queries it excluded **all** results
- * (Firecrawl honors `tbs` only when the underlying index has a clean
- * publish date; both publishers lack one, so the filter is binary-fatal).
- * A hybrid listing-page scrape will replace it; until then recency relies
- * solely on the per-scraper `MAX_ARTICLE_AGE_DAYS` filter.
- */
-export async function firecrawlSearch(
-  query: string,
-  apiKey: string,
-  limit = 10,
-): Promise<FirecrawlSearchResult[]> {
-  const data = await firecrawlPost(
-    '/search',
-    apiKey,
-    { query, limit, sources: [{ type: 'web' }] },
-    SEARCH_TIMEOUT_MS + CLIENT_TIMEOUT_BUFFER_MS,
-  );
-
-  const payload = (data['data'] ?? {}) as Record<string, unknown>;
-  const web = Array.isArray(payload['web']) ? payload['web'] : [];
-
-  return web
-    .map((entry): FirecrawlSearchResult => {
-      const record = (entry ?? {}) as Record<string, unknown>;
-      return {
-        url: typeof record['url'] === 'string' ? record['url'] : '',
-        title: typeof record['title'] === 'string' ? record['title'].trim() : '',
-        description:
-          typeof record['description'] === 'string' ? record['description'].trim() : '',
-      };
-    })
-    .filter((result) => result.url.length > 0 && result.title.length > 0);
-}
-
-/**
  * Scrape a single URL to markdown (main content only). Pull publish time and
- * author from page metadata when present.
+ * author from page metadata when present. Used both for the listing/search
+ * pages (discovery) and for the article body itself.
  */
 export async function firecrawlScrape(
   url: string,
@@ -141,4 +117,40 @@ export async function firecrawlScrape(
     author:
       firstString(metadata['author']) || firstString(metadata['article:author']),
   };
+}
+
+// Inline markdown link syntax: `[title](url)` with an optional `"title"`
+// trailing the URL. Reference-style links (`[t][ref]`) and bare URLs are
+// not matched on purpose — listing pages always render as inline links.
+// The negative lookbehind `(?<!!)` excludes image syntax `![alt](url)` so
+// thumbnail images on listing cards don't leak into the candidate pool
+// (would burn a Firecrawl scrape on a JPG URL).
+const MARKDOWN_LINK_PATTERN = /(?<!!)\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+/**
+ * Pull `{url, title}` from each markdown inline link, in source order, keeping
+ * only those the `predicate` accepts. Titles are trimmed; empty titles and
+ * empty URLs are dropped. Duplicates (by URL) are removed preserving the
+ * first occurrence.
+ *
+ * Stays narrow on purpose: per-source rules (host check, path patterns,
+ * exclude index pages, dedup against `processedUrls`) live in the scraper
+ * predicate so the helper stays generic.
+ */
+export function extractMarkdownLinks(
+  markdown: string,
+  predicate: (link: MarkdownLink) => boolean,
+): MarkdownLink[] {
+  if (!markdown) return [];
+  const seen = new Set<string>();
+  const out: MarkdownLink[] = [];
+  for (const match of markdown.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const title = (match[1] ?? '').trim();
+    const url = (match[2] ?? '').trim();
+    if (!title || !url || seen.has(url)) continue;
+    if (!predicate({ url, title })) continue;
+    seen.add(url);
+    out.push({ url, title });
+  }
+  return out;
 }

--- a/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
@@ -19,26 +19,33 @@ function daysAgoIso(days: number): string {
   return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 }
 
+function listingUrl(theme: ThemeConfig): string {
+  return `https://esgnews.com/?s=${encodeURIComponent(theme.esgNewsSearchTerms)}`;
+}
+
+/** Synthesize a listing-page markdown body from a set of links. */
+function listingMarkdown(links: ReadonlyArray<{ url: string; title: string }>): string {
+  return links.map(({ url, title }) => `[${title}](${url})`).join('\n');
+}
+
 type ScrapeEntry =
   | { markdown: string; publishedTime?: string; author?: string }
   | { status: number };
 
-function installFetch(opts: {
-  search: (query: string) => Array<{ url: string; title: string }>;
-  scrape: Record<string, ScrapeEntry>;
-}): void {
+/**
+ * Mock every Firecrawl `/v2/scrape` call (both listing-page discovery and
+ * per-article scraping). Listing URLs and article URLs are siblings in the
+ * `scrapes` map; absence falls through to a 404.
+ */
+function installFetch(scrapes: Record<string, ScrapeEntry>): void {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url: string, init: { body: string }) => {
-      const body = JSON.parse(init.body) as { query?: string; url?: string };
-      if (url.endsWith('/v2/search')) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ data: { web: opts.search(body.query ?? '') } }),
-        };
+      if (!url.endsWith('/v2/scrape')) {
+        throw new Error(`Unexpected fetch URL ${url} — only /v2/scrape is mocked`);
       }
-      const entry = opts.scrape[body.url ?? ''];
+      const body = JSON.parse(init.body) as { url?: string };
+      const entry = scrapes[body.url ?? ''];
       if (!entry || 'status' in entry) {
         return { ok: false, status: entry ? entry.status : 404, json: async () => ({}) };
       }
@@ -65,25 +72,41 @@ describe('scrapeEsgNews', () => {
     vi.clearAllMocks();
   });
 
+  it('hits the publisher search URL for discovery (recency comes from there)', async () => {
+    const theme = stubTheme({ esgNewsSearchTerms: 'methane policy' });
+    const fetchSpy = vi.fn(async (_url: string, _init: { body: string }) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { markdown: '', metadata: {} } }),
+    }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await scrapeEsgNews([theme], new Set(), [], KEY);
+
+    const requested = (JSON.parse(fetchSpy.mock.calls[0]![1].body) as { url: string }).url;
+    expect(requested).toBe('https://esgnews.com/?s=methane%20policy');
+  });
+
   it('returns a sanitized RawArticle and strips page chrome from markdown', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [{ url: 'https://esgnews.com/nz/', title: 'NZ Climate Law' }],
-      scrape: {
-        'https://esgnews.com/nz/': {
-          markdown:
-            'Climate\n/\nGovernment\n/\nNews\nby ESG News Editorial Team\n' +
-            'Share:\nShare on Facebook\nShare on LinkedIn\n' +
-            'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.\n' +
-            'RELATED ARTICLE: New Zealand Lifts Climate Reporting Thresholds\n' +
-            'Subscribe & Follow for Daily ESG Insights\n' +
-            'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran journalists.',
-          author: 'ESG News Editorial Team',
-          publishedTime: daysAgoIso(3),
-        },
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://esgnews.com/nz/', title: 'NZ Climate Law' }]),
+      },
+      'https://esgnews.com/nz/': {
+        markdown:
+          'Climate\n/\nGovernment\n/\nNews\nby ESG News Editorial Team\n' +
+          'Share:\nShare on Facebook\nShare on LinkedIn\n' +
+          'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.\n' +
+          'RELATED ARTICLE: New Zealand Lifts Climate Reporting Thresholds\n' +
+          'Subscribe & Follow for Daily ESG Insights\n' +
+          'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran journalists.',
+        author: 'ESG News Editorial Team',
+        publishedTime: daysAgoIso(3),
       },
     });
 
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
 
     expect(result).toHaveLength(1);
     const article = result[0]!;
@@ -99,13 +122,116 @@ describe('scrapeEsgNews', () => {
     expect(article.fullContent).not.toMatch(/Editorial Team is comprised of/);
   });
 
-  it('skips results already in processedUrls (no scrape call)', async () => {
+  it('filters tag/category/author/page/region/wp-*/static-page index links out of the listing', async () => {
+    const theme = stubTheme();
+    const scrapedUrls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        if (body.url === listingUrl(theme)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: {
+                markdown: listingMarkdown([
+                  { url: 'https://esgnews.com/tag/methane/', title: 'Methane tag' },
+                  { url: 'https://esgnews.com/category/policy/', title: 'Policy category' },
+                  { url: 'https://esgnews.com/author/someone/', title: 'Author page' },
+                  { url: 'https://esgnews.com/page/12/', title: 'Page 12' },
+                  { url: 'https://esgnews.com/esg-europe/page/15/', title: 'EU index' },
+                  { url: 'https://esgnews.com/esg-americas/page/3/', title: 'Americas index' },
+                  { url: 'https://esgnews.com/feed/', title: 'RSS feed' },
+                  { url: 'https://esgnews.com/wp-admin/edit.php', title: 'WP admin' },
+                  { url: 'https://esgnews.com/wp-content/uploads/2026/x.jpg', title: 'Upload' },
+                  { url: 'https://esgnews.com/wp-json/wp/v2/posts', title: 'WP JSON API' },
+                  { url: 'https://esgnews.com/about/', title: 'About' },
+                  { url: 'https://esgnews.com/contact/', title: 'Contact' },
+                  { url: 'https://esgnews.com/real-article-slug/', title: 'Real Article' },
+                ]),
+                metadata: {},
+              },
+            }),
+          };
+        }
+        scrapedUrls.push(body.url ?? '');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              markdown: 'A real article body about carbon market policy and methane regulation.',
+              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
+            },
+          }),
+        };
+      }),
+    );
+
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
+
+    // Only the real article should have been scraped; no index/static page hit Firecrawl.
+    expect(scrapedUrls).toEqual(['https://esgnews.com/real-article-slug/']);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('https://esgnews.com/real-article-slug/');
+  });
+
+  it('rejects multi-segment paths the prefix list doesn\'t enumerate (depth-1 safety net)', async () => {
+    const theme = stubTheme();
+    const scrapedUrls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        if (body.url === listingUrl(theme)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: {
+                markdown: listingMarkdown([
+                  // Hypothetical new index types (e.g. CMS migration adds these
+                  // overnight); the prefix list wouldn't enumerate them yet,
+                  // but the depth-1 segment check rejects them anyway.
+                  { url: 'https://esgnews.com/topic/methane/', title: 'New topic index' },
+                  { url: 'https://esgnews.com/region/europe/digest/', title: 'Deep listing' },
+                  { url: 'https://esgnews.com/finalists-2026-emissions-rule/', title: 'Real Article' },
+                ]),
+                metadata: {},
+              },
+            }),
+          };
+        }
+        scrapedUrls.push(body.url ?? '');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              markdown: 'A real article body about a finalised emissions rule.',
+              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
+            },
+          }),
+        };
+      }),
+    );
+
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
+
+    expect(scrapedUrls).toEqual(['https://esgnews.com/finalists-2026-emissions-rule/']);
+    expect(result).toHaveLength(1);
+  });
+
+  it('skips results already in processedUrls (no article scrape call)', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [{ url: 'https://esgnews.com/seen/', title: 'Seen Article' }],
-      scrape: {},
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://esgnews.com/seen/', title: 'Seen Article' }]),
+      },
     });
     const result = await scrapeEsgNews(
-      [stubTheme()],
+      [theme],
       new Set(['https://esgnews.com/seen/']),
       [],
       KEY,
@@ -114,14 +240,16 @@ describe('scrapeEsgNews', () => {
   });
 
   it('skips results that duplicate a Carbon Pulse title', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [
-        { url: 'https://esgnews.com/dup/', title: 'Global Methane Pledge Reaches Milestone' },
-      ],
-      scrape: {},
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([
+          { url: 'https://esgnews.com/dup/', title: 'Global Methane Pledge Reaches Milestone' },
+        ]),
+      },
     });
     const result = await scrapeEsgNews(
-      [stubTheme()],
+      [theme],
       new Set(),
       ['Global Methane Pledge Reaches Major Milestone Today'],
       KEY,
@@ -130,131 +258,117 @@ describe('scrapeEsgNews', () => {
   });
 
   it('skips articles older than the age limit', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [{ url: 'https://esgnews.com/old/', title: 'Old Article' }],
-      scrape: {
-        'https://esgnews.com/old/': {
-          markdown: 'This is a sufficiently long article body about carbon markets.',
-          publishedTime: daysAgoIso(120),
-        },
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://esgnews.com/old/', title: 'Old Article' }]),
+      },
+      'https://esgnews.com/old/': {
+        markdown: 'This is a sufficiently long article body about carbon markets.',
+        publishedTime: daysAgoIso(120),
       },
     });
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
     expect(result).toHaveLength(0);
   });
 
   it('skips pages that sanitize to empty (chrome-only)', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [{ url: 'https://esgnews.com/chrome/', title: 'Chrome Only' }],
-      scrape: {
-        'https://esgnews.com/chrome/': {
-          markdown: 'Share:\nShare on Facebook\nSubscribe & Follow\nRELATED ARTICLE: Something',
-          publishedTime: daysAgoIso(1),
-        },
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://esgnews.com/chrome/', title: 'Chrome Only' }]),
+      },
+      'https://esgnews.com/chrome/': {
+        markdown: 'Share:\nShare on Facebook\nSubscribe & Follow\nRELATED ARTICLE: Something',
+        publishedTime: daysAgoIso(1),
       },
     });
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
     expect(result).toHaveLength(0);
   });
 
-  it('continues other themes when one theme search fails', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { query?: string; url?: string };
-        if (url.endsWith('/v2/search')) {
-          if ((body.query ?? '').includes('boom')) {
-            return { ok: false, status: 500, json: async () => ({}) };
-          }
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: { web: [{ url: 'https://esgnews.com/ok/', title: 'Good One' }] },
-            }),
-          };
-        }
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: 'A solid article body about composting infrastructure and policy.',
-              metadata: { 'article:published_time': daysAgoIso(2), author: 'ESG News' },
-            },
-          }),
-        };
-      }),
-    );
+  it('continues other themes when one theme discovery fails', async () => {
+    const badTheme = stubTheme({ name: 'Bad', esgNewsSearchTerms: 'boom' });
+    const goodTheme = stubTheme({ name: 'Good' });
+    installFetch({
+      [listingUrl(badTheme)]: { status: 500 },
+      [listingUrl(goodTheme)]: {
+        markdown: listingMarkdown([{ url: 'https://esgnews.com/ok/', title: 'Good One' }]),
+      },
+      'https://esgnews.com/ok/': {
+        markdown: 'A solid article body about composting infrastructure and policy.',
+        publishedTime: daysAgoIso(2),
+        author: 'ESG News',
+      },
+    });
 
-    const result = await scrapeEsgNews(
-      [stubTheme({ name: 'Bad', esgNewsSearchTerms: 'boom' }), stubTheme({ name: 'Good' })],
-      new Set(),
-      [],
-      KEY,
-    );
+    const result = await scrapeEsgNews([badTheme, goodTheme], new Set(), [], KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.mainTheme).toBe('Good');
   });
 
   it('skips a single article whose scrape fails but keeps the others', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [
-        { url: 'https://esgnews.com/bad/', title: 'Bad Scrape' },
-        { url: 'https://esgnews.com/good/', title: 'Good Scrape' },
-      ],
-      scrape: {
-        'https://esgnews.com/bad/': { status: 500 },
-        'https://esgnews.com/good/': {
-          markdown: 'A complete article body discussing carbon market regulation in depth.',
-          publishedTime: daysAgoIso(1),
-        },
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([
+          { url: 'https://esgnews.com/bad/', title: 'Bad Scrape' },
+          { url: 'https://esgnews.com/good/', title: 'Good Scrape' },
+        ]),
+      },
+      'https://esgnews.com/bad/': { status: 500 },
+      'https://esgnews.com/good/': {
+        markdown: 'A complete article body discussing carbon market regulation in depth.',
+        publishedTime: daysAgoIso(1),
       },
     });
 
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://esgnews.com/good/');
   });
 
   it('skips an article with no parseable publish date (parity with carbon-pulse)', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [{ url: 'https://esgnews.com/undated/', title: 'Undated' }],
-      scrape: {
-        'https://esgnews.com/undated/': {
-          markdown: 'A perfectly valid long article body with no date metadata.',
-          publishedTime: '',
-        },
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://esgnews.com/undated/', title: 'Undated' }]),
+      },
+      'https://esgnews.com/undated/': {
+        markdown: 'A perfectly valid long article body with no date metadata.',
+        publishedTime: '',
       },
     });
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
     expect(result).toHaveLength(0);
   });
 
   it('scrapes at most MAX_ARTICLES_PER_THEME eligible results', async () => {
-    let scrapeCalls = 0;
+    const theme = stubTheme();
+    let articleScrapes = 0;
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (url: string, init: { body: string }) => {
+      vi.fn(async (_url: string, init: { body: string }) => {
         const body = JSON.parse(init.body) as { url?: string };
-        if (url.endsWith('/v2/search')) {
+        if (body.url === listingUrl(theme)) {
           return {
             ok: true,
             status: 200,
             json: async () => ({
               data: {
-                web: [
+                markdown: listingMarkdown([
                   { url: 'https://esgnews.com/1/', title: 'One' },
                   { url: 'https://esgnews.com/2/', title: 'Two' },
                   { url: 'https://esgnews.com/3/', title: 'Three' },
-                ],
+                ]),
+                metadata: {},
               },
             }),
           };
         }
-        scrapeCalls += 1;
+        articleScrapes += 1;
         return {
           ok: true,
           status: 200,
@@ -268,68 +382,92 @@ describe('scrapeEsgNews', () => {
       }),
     );
 
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
 
-    expect(scrapeCalls).toBe(2);
+    expect(articleScrapes).toBe(2);
     expect(result).toHaveLength(2);
   });
 
-  it('aborts the theme on a quota error (402) without burning the rest of the loop', async () => {
-    installFetch({
-      search: (query) =>
-        query.includes('quota')
-          ? [
-              { url: 'https://esgnews.com/q1/', title: 'Q1' },
-              { url: 'https://esgnews.com/q2/', title: 'Q2' },
-            ]
-          : [{ url: 'https://esgnews.com/ok/', title: 'OK' }],
-      scrape: {
-        'https://esgnews.com/q1/': { status: 402 },
-        'https://esgnews.com/q2/': { status: 402 },
+  it('aborts the remaining themes when the listing scrape itself returns 402 (quota)', async () => {
+    const quotaTheme = stubTheme({ name: 'First', esgNewsSearchTerms: 'first' });
+    const wouldBeNextTheme = stubTheme({ name: 'Second', esgNewsSearchTerms: 'second' });
+    const requestedUrls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        requestedUrls.push(body.url ?? '');
+        if (body.url === listingUrl(quotaTheme)) {
+          return { ok: false, status: 402, json: async () => ({}) };
+        }
+        return { ok: true, status: 200, json: async () => ({ data: { markdown: '', metadata: {} } }) };
+      }),
+    );
+
+    const result = await scrapeEsgNews([quotaTheme, wouldBeNextTheme], new Set(), [], KEY);
+
+    expect(result).toEqual([]);
+    // The second theme's listing must NOT be requested — the loop short-circuited.
+    expect(requestedUrls).not.toContain(listingUrl(wouldBeNextTheme));
+  });
+
+  it.each([402, 429] as const)(
+    'aborts the theme on a Firecrawl %s quota/rate-limit response from per-article scrapes',
+    async (status) => {
+      const quotaTheme = stubTheme({ name: 'Quota', esgNewsSearchTerms: 'quota' });
+      const fineTheme = stubTheme({ name: 'Fine' });
+      installFetch({
+        [listingUrl(quotaTheme)]: {
+          markdown: listingMarkdown([
+            { url: 'https://esgnews.com/q1/', title: 'Q1' },
+            { url: 'https://esgnews.com/q2/', title: 'Q2' },
+          ]),
+        },
+        [listingUrl(fineTheme)]: {
+          markdown: listingMarkdown([{ url: 'https://esgnews.com/ok/', title: 'OK' }]),
+        },
+        'https://esgnews.com/q1/': { status },
+        'https://esgnews.com/q2/': { status },
         'https://esgnews.com/ok/': {
           markdown: 'A healthy article body about carbon market regulation.',
           publishedTime: daysAgoIso(1),
         },
-      },
-    });
+      });
 
-    const result = await scrapeEsgNews(
-      [stubTheme({ name: 'Quota', esgNewsSearchTerms: 'quota' }), stubTheme({ name: 'Fine' })],
-      new Set(),
-      [],
-      KEY,
-    );
+      const result = await scrapeEsgNews([quotaTheme, fineTheme], new Set(), [], KEY);
 
-    expect(result).toHaveLength(1);
-    expect(result[0]!.mainTheme).toBe('Fine');
-  });
+      expect(result).toHaveLength(1);
+      expect(result[0]!.mainTheme).toBe('Fine');
+    },
+  );
 
   it('fills the per-theme cap from later candidates when early ones are skipped', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [
-        { url: 'https://esgnews.com/undated/', title: 'Undated' },
-        { url: 'https://esgnews.com/stale/', title: 'Stale' },
-        { url: 'https://esgnews.com/good1/', title: 'Good 1' },
-        { url: 'https://esgnews.com/good2/', title: 'Good 2' },
-      ],
-      scrape: {
-        'https://esgnews.com/undated/': { markdown: 'Valid body but no date.', publishedTime: '' },
-        'https://esgnews.com/stale/': {
-          markdown: 'Valid body but ancient.',
-          publishedTime: daysAgoIso(120),
-        },
-        'https://esgnews.com/good1/': {
-          markdown: 'Fresh article one about carbon markets and policy.',
-          publishedTime: daysAgoIso(1),
-        },
-        'https://esgnews.com/good2/': {
-          markdown: 'Fresh article two about composting infrastructure.',
-          publishedTime: daysAgoIso(2),
-        },
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([
+          { url: 'https://esgnews.com/undated/', title: 'Undated' },
+          { url: 'https://esgnews.com/stale/', title: 'Stale' },
+          { url: 'https://esgnews.com/good1/', title: 'Good 1' },
+          { url: 'https://esgnews.com/good2/', title: 'Good 2' },
+        ]),
+      },
+      'https://esgnews.com/undated/': { markdown: 'Valid body but no date.', publishedTime: '' },
+      'https://esgnews.com/stale/': {
+        markdown: 'Valid body but ancient.',
+        publishedTime: daysAgoIso(120),
+      },
+      'https://esgnews.com/good1/': {
+        markdown: 'Fresh article one about carbon markets and policy.',
+        publishedTime: daysAgoIso(1),
+      },
+      'https://esgnews.com/good2/': {
+        markdown: 'Fresh article two about composting infrastructure.',
+        publishedTime: daysAgoIso(2),
       },
     });
 
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
 
     expect(result.map((article) => article.url)).toEqual([
       'https://esgnews.com/good1/',
@@ -338,42 +476,51 @@ describe('scrapeEsgNews', () => {
   });
 
   it('preserves articles already collected when a later scrape hits a quota error', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: () => [
-        { url: 'https://esgnews.com/collected/', title: 'Collected' },
-        { url: 'https://esgnews.com/quota/', title: 'Quota' },
-      ],
-      scrape: {
-        'https://esgnews.com/collected/': {
-          markdown: 'A solid article body about methane monitoring.',
-          publishedTime: daysAgoIso(1),
-        },
-        'https://esgnews.com/quota/': { status: 402 },
+      [listingUrl(theme)]: {
+        markdown: listingMarkdown([
+          { url: 'https://esgnews.com/collected/', title: 'Collected' },
+          { url: 'https://esgnews.com/quota/', title: 'Quota' },
+        ]),
       },
+      'https://esgnews.com/collected/': {
+        markdown: 'A solid article body about methane monitoring.',
+        publishedTime: daysAgoIso(1),
+      },
+      'https://esgnews.com/quota/': { status: 402 },
     });
 
-    const result = await scrapeEsgNews([stubTheme()], new Set(), [], KEY);
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://esgnews.com/collected/');
   });
 
   it('does not re-scrape an article that already matched an earlier theme', async () => {
-    let scrapeCalls = 0;
+    const themeA = stubTheme({ name: 'Theme A', esgNewsSearchTerms: 'aaa' });
+    const themeB = stubTheme({ name: 'Theme B', esgNewsSearchTerms: 'bbb' });
+    let articleScrapes = 0;
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (url: string, init: { body: string }) => {
-        if (url.endsWith('/v2/search')) {
-          // Every theme search surfaces the SAME article.
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        if (body.url === listingUrl(themeA) || body.url === listingUrl(themeB)) {
+          // Every theme listing surfaces the SAME article.
           return {
             ok: true,
             status: 200,
             json: async () => ({
-              data: { web: [{ url: 'https://esgnews.com/shared/', title: 'Shared' }] },
+              data: {
+                markdown: listingMarkdown([
+                  { url: 'https://esgnews.com/shared/', title: 'Shared' },
+                ]),
+                metadata: {},
+              },
             }),
           };
         }
-        scrapeCalls += 1;
+        articleScrapes += 1;
         return {
           ok: true,
           status: 200,
@@ -387,17 +534,9 @@ describe('scrapeEsgNews', () => {
       }),
     );
 
-    const result = await scrapeEsgNews(
-      [
-        stubTheme({ name: 'Theme A', esgNewsSearchTerms: 'aaa' }),
-        stubTheme({ name: 'Theme B', esgNewsSearchTerms: 'bbb' }),
-      ],
-      new Set(),
-      [],
-      KEY,
-    );
+    const result = await scrapeEsgNews([themeA, themeB], new Set(), [], KEY);
 
-    expect(scrapeCalls).toBe(1);
+    expect(articleScrapes).toBe(1);
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://esgnews.com/shared/');
   });

--- a/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
@@ -177,6 +177,55 @@ describe('scrapeEsgNews', () => {
     expect(result[0]!.url).toBe('https://esgnews.com/real-article-slug/');
   });
 
+  it('filters index paths regardless of trailing slash (no-trailing-slash variants too)', async () => {
+    // Cursor bot finding on PR #36: prefix-list with trailing `/` would let
+    // `https://esgnews.com/about` (no slash) through. First-segment matching
+    // catches both `/about` and `/about/`.
+    const theme = stubTheme();
+    const scrapedUrls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        if (body.url === listingUrl(theme)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: {
+                markdown: listingMarkdown([
+                  { url: 'https://esgnews.com/about', title: 'About no-slash' },
+                  { url: 'https://esgnews.com/tag', title: 'Tag root no-slash' },
+                  { url: 'https://esgnews.com/wp-admin', title: 'WP admin no-slash' },
+                  { url: 'https://esgnews.com/feedback-policy/', title: 'Real Article (feedback)' },
+                ]),
+                metadata: {},
+              },
+            }),
+          };
+        }
+        scrapedUrls.push(body.url ?? '');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: {
+              markdown: 'A feedback-policy article body — should be scraped, not excluded by /feed.',
+              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
+            },
+          }),
+        };
+      }),
+    );
+
+    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
+
+    // /about, /tag, /wp-admin all rejected (slug-less or known index first-segment).
+    // /feedback-policy/ accepted (first segment is "feedback-policy", not "feed").
+    expect(scrapedUrls).toEqual(['https://esgnews.com/feedback-policy/']);
+    expect(result).toHaveLength(1);
+  });
+
   it('rejects multi-segment paths the prefix list doesn\'t enumerate (depth-1 safety net)', async () => {
     const theme = stubTheme();
     const scrapedUrls: string[] = [];

--- a/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
@@ -11,6 +11,7 @@ import { scrapeTrellis } from '../trellis.js';
 
 const KEY = 'fc-test-key';
 const ANTHROPIC = 'sk-test';
+const CURATION_LISTING_URL = 'https://trellis.net/articles/';
 
 function stubTheme(overrides: Partial<ThemeConfig> = {}): ThemeConfig {
   return {
@@ -27,27 +28,32 @@ function daysAgoIso(days: number): string {
   return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 }
 
-type WebResult = { url: string; title: string; description?: string };
+function themeListingUrl(theme: ThemeConfig): string {
+  return `https://trellis.net/?s=${encodeURIComponent(theme.trellisSearchTerms)}`;
+}
+
+function listingMarkdown(links: ReadonlyArray<{ url: string; title: string }>): string {
+  return links.map(({ url, title }) => `[${title}](${url})`).join('\n');
+}
+
 type ScrapeEntry =
   | { markdown: string; publishedTime?: string; author?: string }
   | { status: number };
 
-function installFetch(opts: {
-  search: (query: string) => WebResult[];
-  scrape: Record<string, ScrapeEntry>;
-}): void {
+/**
+ * Mock every Firecrawl `/v2/scrape` call. Listing URLs (per-theme search +
+ * curation broad pool) and article URLs are siblings in the `scrapes` map;
+ * absence falls through to a 404.
+ */
+function installFetch(scrapes: Record<string, ScrapeEntry>): void {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url: string, init: { body: string }) => {
-      const body = JSON.parse(init.body) as { query?: string; url?: string };
-      if (url.endsWith('/v2/search')) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ data: { web: opts.search(body.query ?? '') } }),
-        };
+      if (!url.endsWith('/v2/scrape')) {
+        throw new Error(`Unexpected fetch URL ${url} — only /v2/scrape is mocked`);
       }
-      const entry = opts.scrape[body.url ?? ''];
+      const body = JSON.parse(init.body) as { url?: string };
+      const entry = scrapes[body.url ?? ''];
       if (!entry || 'status' in entry) {
         return { ok: false, status: entry ? entry.status : 404, json: async () => ({}) };
       }
@@ -68,8 +74,6 @@ function installFetch(opts: {
   );
 }
 
-const isCuration = (query: string): boolean => query.includes('decarbonization circular economy');
-
 describe('scrapeTrellis', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -78,21 +82,23 @@ describe('scrapeTrellis', () => {
 
   it('extracts a sanitized RawArticle per theme and strips chrome', async () => {
     vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const theme = stubTheme();
     installFetch({
-      search: (q) => (isCuration(q) ? [] : [{ url: 'https://trellis.net/article/a/', title: 'A' }]),
-      scrape: {
-        'https://trellis.net/article/a/': {
-          markdown:
-            'Share on Facebook\nSubscribe & Follow\n' +
-            'Trellis reports a major circular-economy policy shift this quarter.\n' +
-            'RELATED ARTICLE: Something Else',
-          author: 'Jane Doe',
-          publishedTime: daysAgoIso(3),
-        },
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/a/', title: 'A' }]),
+      },
+      [CURATION_LISTING_URL]: { markdown: '' },
+      'https://trellis.net/article/a/': {
+        markdown:
+          'Share on Facebook\nSubscribe & Follow\n' +
+          'Trellis reports a major circular-economy policy shift this quarter.\n' +
+          'RELATED ARTICLE: Something Else',
+        author: 'Jane Doe',
+        publishedTime: daysAgoIso(3),
       },
     });
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.source).toBe('trellis');
@@ -101,14 +107,40 @@ describe('scrapeTrellis', () => {
     expect(result[0]!.fullContent).not.toMatch(/Share on Facebook|Subscribe & Follow|RELATED ARTICLE:/);
   });
 
+  it('hits the publisher search URL for per-theme discovery', async () => {
+    const theme = stubTheme({ trellisSearchTerms: 'methane policy' });
+    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const seen = new Set<string>();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        seen.add(body.url ?? '');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: { markdown: '', metadata: {} } }),
+        };
+      }),
+    );
+
+    await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
+
+    expect(seen).toContain('https://trellis.net/?s=methane%20policy');
+    expect(seen).toContain(CURATION_LISTING_URL);
+  });
+
   it('skips URLs already in processedUrls (no scrape)', async () => {
     vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const theme = stubTheme();
     installFetch({
-      search: (q) => (isCuration(q) ? [] : [{ url: 'https://trellis.net/article/seen/', title: 'Seen' }]),
-      scrape: {},
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/seen/', title: 'Seen' }]),
+      },
+      [CURATION_LISTING_URL]: { markdown: '' },
     });
     const result = await scrapeTrellis(
-      [stubTheme()],
+      [theme],
       new Set(['https://trellis.net/article/seen/']),
       ANTHROPIC,
       KEY,
@@ -118,105 +150,85 @@ describe('scrapeTrellis', () => {
 
   it('skips undated and too-old articles', async () => {
     vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const theme = stubTheme();
     installFetch({
-      search: (q) =>
-        isCuration(q)
-          ? []
-          : [
-              { url: 'https://trellis.net/article/undated/', title: 'Undated' },
-              { url: 'https://trellis.net/article/old/', title: 'Old' },
-            ],
-      scrape: {
-        'https://trellis.net/article/undated/': { markdown: 'Valid body, no date.', publishedTime: '' },
-        'https://trellis.net/article/old/': {
-          markdown: 'Valid body, ancient.',
-          publishedTime: daysAgoIso(200),
-        },
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([
+          { url: 'https://trellis.net/article/undated/', title: 'Undated' },
+          { url: 'https://trellis.net/article/old/', title: 'Old' },
+        ]),
+      },
+      [CURATION_LISTING_URL]: { markdown: '' },
+      'https://trellis.net/article/undated/': { markdown: 'Valid body, no date.', publishedTime: '' },
+      'https://trellis.net/article/old/': {
+        markdown: 'Valid body, ancient.',
+        publishedTime: daysAgoIso(200),
       },
     });
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
     expect(result).toHaveLength(0);
   });
 
   it('skips a page that sanitizes to empty (chrome-only)', async () => {
     vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const theme = stubTheme();
     installFetch({
-      search: (q) => (isCuration(q) ? [] : [{ url: 'https://trellis.net/article/chrome/', title: 'Chrome' }]),
-      scrape: {
-        'https://trellis.net/article/chrome/': {
-          markdown: 'Share on Facebook\nSubscribe & Follow\nRELATED ARTICLE: x',
-          publishedTime: daysAgoIso(1),
-        },
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/chrome/', title: 'Chrome' }]),
+      },
+      [CURATION_LISTING_URL]: { markdown: '' },
+      'https://trellis.net/article/chrome/': {
+        markdown: 'Share on Facebook\nSubscribe & Follow\nRELATED ARTICLE: x',
+        publishedTime: daysAgoIso(1),
       },
     });
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
     expect(result).toHaveLength(0);
   });
 
-  it('continues other themes when one theme search fails', async () => {
+  it('continues other themes when one theme discovery fails', async () => {
     vi.mocked(curateTrellisArticles).mockResolvedValue([]);
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { query?: string; url?: string };
-        if (url.endsWith('/v2/search')) {
-          if ((body.query ?? '').includes('boom')) {
-            return { ok: false, status: 500, json: async () => ({}) };
-          }
-          if (isCuration(body.query ?? '')) {
-            return { ok: true, status: 200, json: async () => ({ data: { web: [] } }) };
-          }
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({ data: { web: [{ url: 'https://trellis.net/article/ok/', title: 'OK' }] } }),
-          };
-        }
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: 'A solid Trellis article body about composting policy.',
-              metadata: { 'article:published_time': daysAgoIso(2), author: 'Trellis' },
-            },
-          }),
-        };
-      }),
-    );
+    const badTheme = stubTheme({ name: 'Bad', trellisSearchTerms: 'boom' });
+    const goodTheme = stubTheme({ name: 'Good' });
+    installFetch({
+      [themeListingUrl(badTheme)]: { status: 500 },
+      [themeListingUrl(goodTheme)]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/ok/', title: 'OK' }]),
+      },
+      [CURATION_LISTING_URL]: { markdown: '' },
+      'https://trellis.net/article/ok/': {
+        markdown: 'A solid Trellis article body about composting policy.',
+        publishedTime: daysAgoIso(2),
+        author: 'Trellis',
+      },
+    });
 
-    const result = await scrapeTrellis(
-      [stubTheme({ name: 'Bad', trellisSearchTerms: 'boom' }), stubTheme({ name: 'Good' })],
-      new Set(),
-      ANTHROPIC,
-      KEY,
-    );
+    const result = await scrapeTrellis([badTheme, goodTheme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.mainTheme).toBe('Good');
   });
 
-  it('adds curated picks (excerpt from search description, all THEMES passed to curator)', async () => {
+  it('adds curated picks; candidates carry title-based excerpt and all THEMES go to curator', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: (q) =>
-        isCuration(q)
-          ? [
-              { url: 'https://trellis.net/article/c1/', title: 'Cand 1', description: 'Excerpt one.' },
-              { url: 'https://trellis.net/article/c2/', title: 'Cand 2', description: 'Excerpt two.' },
-            ]
-          : [],
-      scrape: {
-        'https://trellis.net/article/c1/': {
-          markdown: 'Curated article one body about methane abatement.',
-          publishedTime: daysAgoIso(1),
-        },
+      [themeListingUrl(theme)]: { markdown: '' },
+      [CURATION_LISTING_URL]: {
+        markdown: listingMarkdown([
+          { url: 'https://trellis.net/article/c1/', title: 'Cand 1' },
+          { url: 'https://trellis.net/article/c2/', title: 'Cand 2' },
+        ]),
+      },
+      'https://trellis.net/article/c1/': {
+        markdown: 'Curated article one body about methane abatement.',
+        publishedTime: daysAgoIso(1),
       },
     });
     vi.mocked(curateTrellisArticles).mockResolvedValue([
       { url: 'https://trellis.net/article/c1/', mainTheme: 'Methane & Super Pollutants' },
     ]);
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://trellis.net/article/c1/');
@@ -226,180 +238,214 @@ describe('scrapeTrellis', () => {
     expect(candidates[0]).toMatchObject({
       url: 'https://trellis.net/article/c1/',
       title: 'Cand 1',
-      excerpt: 'Excerpt one.',
+      // Markdown link extraction can't see the publisher's listing-card
+      // excerpt, so we fall back to the title (matches the curator contract).
+      excerpt: 'Cand 1',
       date: '',
     });
     expect(themeNames).toEqual(THEMES.map((theme) => theme.name));
   });
 
   it('does not call the curator when the candidate pool is empty', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: (q) => (isCuration(q) ? [] : [{ url: 'https://trellis.net/article/t/', title: 'T' }]),
-      scrape: {
-        'https://trellis.net/article/t/': {
-          markdown: 'A per-theme Trellis article body about waste policy.',
-          publishedTime: daysAgoIso(1),
-        },
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/t/', title: 'T' }]),
+      },
+      [CURATION_LISTING_URL]: { markdown: '' },
+      'https://trellis.net/article/t/': {
+        markdown: 'A per-theme Trellis article body about waste policy.',
+        publishedTime: daysAgoIso(1),
       },
     });
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
   });
 
-  it('returns only per-theme articles when the curation search fails (resilience)', async () => {
+  it('returns only per-theme articles when the curation discovery fails (resilience)', async () => {
     vi.mocked(curateTrellisArticles).mockResolvedValue([]);
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { query?: string };
-        if (url.endsWith('/v2/search')) {
-          if (isCuration(body.query ?? '')) return { ok: false, status: 500, json: async () => ({}) };
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({ data: { web: [{ url: 'https://trellis.net/article/pt/', title: 'PT' }] } }),
-          };
-        }
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: 'Per-theme body about circular economy in depth.',
-              metadata: { 'article:published_time': daysAgoIso(1), author: 'Trellis' },
-            },
-          }),
-        };
-      }),
-    );
+    const theme = stubTheme();
+    installFetch({
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/pt/', title: 'PT' }]),
+      },
+      [CURATION_LISTING_URL]: { status: 500 },
+      'https://trellis.net/article/pt/': {
+        markdown: 'Per-theme body about circular economy in depth.',
+        publishedTime: daysAgoIso(1),
+        author: 'Trellis',
+      },
+    });
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://trellis.net/article/pt/');
     expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
   });
 
-  it('keeps partial curated picks when a later pick hits a quota error', async () => {
+  it('fills the per-theme cap from later candidates when early ones are skipped (cap on successful extractions)', async () => {
+    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const theme = stubTheme();
     installFetch({
-      search: (q) =>
-        isCuration(q)
-          ? [
-              { url: 'https://trellis.net/article/good/', title: 'Good', description: 'e' },
-              { url: 'https://trellis.net/article/quota/', title: 'Quota', description: 'e' },
-            ]
-          : [],
-      scrape: {
-        'https://trellis.net/article/good/': {
-          markdown: 'Good curated body about emissions monitoring.',
-          publishedTime: daysAgoIso(1),
-        },
-        'https://trellis.net/article/quota/': { status: 402 },
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([
+          { url: 'https://trellis.net/article/undated/', title: 'Undated' },
+          { url: 'https://trellis.net/article/stale/', title: 'Stale' },
+          { url: 'https://trellis.net/article/good/', title: 'Good' },
+        ]),
       },
+      [CURATION_LISTING_URL]: { markdown: '' },
+      'https://trellis.net/article/undated/': { markdown: 'Body, no date.', publishedTime: '' },
+      'https://trellis.net/article/stale/': {
+        markdown: 'Body, ancient.',
+        publishedTime: daysAgoIso(200),
+      },
+      'https://trellis.net/article/good/': {
+        markdown: 'Fresh Trellis article body about climate finance.',
+        publishedTime: daysAgoIso(1),
+      },
+    });
+
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
+
+    expect(result.map((article) => article.url)).toEqual(['https://trellis.net/article/good/']);
+  });
+
+  it('returns only per-theme articles when the curator itself throws (Anthropic outage)', async () => {
+    vi.mocked(curateTrellisArticles).mockRejectedValue(new Error('anthropic 401'));
+    const theme = stubTheme();
+    installFetch({
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/pt/', title: 'PT' }]),
+      },
+      [CURATION_LISTING_URL]: {
+        markdown: listingMarkdown([
+          { url: 'https://trellis.net/article/c1/', title: 'Cand 1' },
+        ]),
+      },
+      'https://trellis.net/article/pt/': {
+        markdown: 'Per-theme Trellis article about waste policy.',
+        publishedTime: daysAgoIso(1),
+      },
+    });
+
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe('https://trellis.net/article/pt/');
+  });
+
+  it('keeps partial curated picks when a later pick hits a quota error', async () => {
+    const theme = stubTheme();
+    installFetch({
+      [themeListingUrl(theme)]: { markdown: '' },
+      [CURATION_LISTING_URL]: {
+        markdown: listingMarkdown([
+          { url: 'https://trellis.net/article/good/', title: 'Good' },
+          { url: 'https://trellis.net/article/quota/', title: 'Quota' },
+        ]),
+      },
+      'https://trellis.net/article/good/': {
+        markdown: 'Good curated body about emissions monitoring.',
+        publishedTime: daysAgoIso(1),
+      },
+      'https://trellis.net/article/quota/': { status: 402 },
     });
     vi.mocked(curateTrellisArticles).mockResolvedValue([
       { url: 'https://trellis.net/article/good/', mainTheme: 'Carbon Markets' },
       { url: 'https://trellis.net/article/quota/', mainTheme: 'Carbon Markets' },
     ]);
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://trellis.net/article/good/');
   });
 
-  it('skips the curation flow entirely when a per-theme quota error occurs', async () => {
-    installFetch({
-      search: (q) =>
-        isCuration(q)
-          ? [{ url: 'https://trellis.net/article/curated/', title: 'Curated' }]
-          : [{ url: 'https://trellis.net/article/q/', title: 'Q' }],
-      scrape: {
-        'https://trellis.net/article/q/': { status: 402 },
+  it.each([402, 429] as const)(
+    'skips the curation flow entirely when a per-theme Firecrawl %s quota/rate-limit response occurs',
+    async (status) => {
+      const theme = stubTheme();
+      installFetch({
+        [themeListingUrl(theme)]: {
+          markdown: listingMarkdown([{ url: 'https://trellis.net/article/q/', title: 'Q' }]),
+        },
+        [CURATION_LISTING_URL]: {
+          markdown: listingMarkdown([
+            { url: 'https://trellis.net/article/curated/', title: 'Curated' },
+          ]),
+        },
+        'https://trellis.net/article/q/': { status },
         'https://trellis.net/article/curated/': {
           markdown: 'Should never be scraped because quota aborted first.',
           publishedTime: daysAgoIso(1),
         },
-      },
-    });
+      });
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+      const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
-    expect(result).toHaveLength(0);
-    expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
-  });
+      expect(result).toHaveLength(0);
+      expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
+    },
+  );
 
-  it('skips curation when the theme SEARCH itself hits a quota error', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { query?: string };
-        if (url.endsWith('/v2/search')) {
-          // Theme search returns 402 directly (not the scrape).
-          if (!isCuration(body.query ?? '')) {
-            return { ok: false, status: 402, json: async () => ({}) };
-          }
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({ data: { web: [{ url: 'https://trellis.net/article/c/', title: 'C' }] } }),
-          };
-        }
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: { markdown: 'never reached', metadata: { 'article:published_time': daysAgoIso(1) } },
-          }),
-        };
-      }),
-    );
-
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
-
-    expect(result).toHaveLength(0);
-    expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
-  });
-
-  it('rejects off-domain and non-article URLs from search results', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+  it('skips curation when the per-theme listing itself returns 402', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: (q) =>
-        isCuration(q)
-          ? []
-          : [
-              { url: 'https://evil.com/article/x/', title: 'Off domain' },
-              { url: 'https://trellis.net/about/', title: 'Not an article' },
-              { url: 'https://trellis.net/article/ok/', title: 'Valid' },
-            ],
-      scrape: {
-        'https://trellis.net/article/ok/': {
-          markdown: 'A valid Trellis article body about emissions policy.',
-          publishedTime: daysAgoIso(1),
-        },
+      [themeListingUrl(theme)]: { status: 402 },
+      [CURATION_LISTING_URL]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/c/', title: 'C' }]),
+      },
+      'https://trellis.net/article/c/': {
+        markdown: 'Should never be scraped — discovery quota already exhausted.',
+        publishedTime: daysAgoIso(1),
       },
     });
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
+
+    expect(result).toHaveLength(0);
+    expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
+  });
+
+  it('rejects off-domain and non-article URLs from listings', async () => {
+    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const theme = stubTheme();
+    installFetch({
+      [themeListingUrl(theme)]: {
+        markdown: listingMarkdown([
+          { url: 'https://evil.com/article/x/', title: 'Off domain' },
+          { url: 'https://trellis.net/about/', title: 'Not an article' },
+          { url: 'https://trellis.net/article/ok/', title: 'Valid' },
+        ]),
+      },
+      [CURATION_LISTING_URL]: { markdown: '' },
+      'https://trellis.net/article/ok/': {
+        markdown: 'A valid Trellis article body about emissions policy.',
+        publishedTime: daysAgoIso(1),
+      },
+    });
+
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://trellis.net/article/ok/');
   });
 
   it('deduplicates repeated curator picks (scrapes a URL once)', async () => {
+    const theme = stubTheme();
     installFetch({
-      search: (q) =>
-        isCuration(q)
-          ? [{ url: 'https://trellis.net/article/dup/', title: 'Dup', description: 'e' }]
-          : [],
-      scrape: {
-        'https://trellis.net/article/dup/': {
-          markdown: 'A curated article body about circular economy finance.',
-          publishedTime: daysAgoIso(1),
-        },
+      [themeListingUrl(theme)]: { markdown: '' },
+      [CURATION_LISTING_URL]: {
+        markdown: listingMarkdown([{ url: 'https://trellis.net/article/dup/', title: 'Dup' }]),
+      },
+      'https://trellis.net/article/dup/': {
+        markdown: 'A curated article body about circular economy finance.',
+        publishedTime: daysAgoIso(1),
       },
     });
     vi.mocked(curateTrellisArticles).mockResolvedValue([
@@ -407,7 +453,7 @@ describe('scrapeTrellis', () => {
       { url: 'https://trellis.net/article/dup/', mainTheme: 'Carbon Markets' },
     ]);
 
-    const result = await scrapeTrellis([stubTheme()], new Set(), ANTHROPIC, KEY);
+    const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://trellis.net/article/dup/');
@@ -415,22 +461,33 @@ describe('scrapeTrellis', () => {
 
   it('does not re-scrape an article that already matched an earlier theme', async () => {
     vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    const themeA = stubTheme({ name: 'Theme A', trellisSearchTerms: 'aaa' });
+    const themeB = stubTheme({ name: 'Theme B', trellisSearchTerms: 'bbb' });
     let scrapeCalls = 0;
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { query?: string };
-        if (url.endsWith('/v2/search')) {
-          if (isCuration(body.query ?? '')) {
-            return { ok: true, status: 200, json: async () => ({ data: { web: [] } }) };
-          }
-          // Every theme search surfaces the SAME article.
+      vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as { url?: string };
+        if (body.url === themeListingUrl(themeA) || body.url === themeListingUrl(themeB)) {
+          // Every theme listing surfaces the SAME article.
           return {
             ok: true,
             status: 200,
             json: async () => ({
-              data: { web: [{ url: 'https://trellis.net/article/shared/', title: 'Shared' }] },
+              data: {
+                markdown: listingMarkdown([
+                  { url: 'https://trellis.net/article/shared/', title: 'Shared' },
+                ]),
+                metadata: {},
+              },
             }),
+          };
+        }
+        if (body.url === CURATION_LISTING_URL) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ data: { markdown: '', metadata: {} } }),
           };
         }
         scrapeCalls += 1;
@@ -447,15 +504,7 @@ describe('scrapeTrellis', () => {
       }),
     );
 
-    const result = await scrapeTrellis(
-      [
-        stubTheme({ name: 'Theme A', trellisSearchTerms: 'aaa' }),
-        stubTheme({ name: 'Theme B', trellisSearchTerms: 'bbb' }),
-      ],
-      new Set(),
-      ANTHROPIC,
-      KEY,
-    );
+    const result = await scrapeTrellis([themeA, themeB], new Set(), ANTHROPIC, KEY);
 
     expect(scrapeCalls).toBe(1);
     expect(result).toHaveLength(1);

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -1,11 +1,67 @@
 import { sanitizeArticleText } from '../helpers/content.helpers.js';
 import { parseDate } from '../helpers/date.helpers.js';
-import { FirecrawlError, firecrawlScrape, firecrawlSearch } from '../helpers/firecrawl.helpers.js';
+import {
+  FirecrawlError,
+  extractMarkdownLinks,
+  firecrawlScrape,
+} from '../helpers/firecrawl.helpers.js';
 import type { RawArticle, ThemeConfig } from '../types.js';
 
 const MAX_ARTICLES_PER_THEME = 2;
 const MAX_ARTICLE_AGE_DAYS = 30;
-const SEARCH_LIMIT = 10;
+const LISTING_URL_BASE = 'https://esgnews.com/?s=';
+
+// ESG News article permalinks are slug-only at the root (`/some-slug/`).
+// These prefixes mark tag/category/author/pagination/region/static-page
+// routes that the search page also links to — exclude them so we don't
+// waste credits scraping a non-article page (the old `/search` flow
+// burnt 16 scrapes on these in the 2026-05-19 validation run). All
+// entries end with `/` so they never accidentally swallow a real slug
+// (e.g. `/feed` would have excluded a legitimate `/feedback-policy/`).
+const ESG_INDEX_PATH_PREFIXES: readonly string[] = [
+  '/tag/',
+  '/category/',
+  '/author/',
+  '/page/',
+  '/esg-europe/',
+  '/esg-americas/',
+  '/esg-africa/',
+  '/esg-asia-pacific/',
+  '/feed/',
+  '/wp-admin/',
+  '/wp-content/',
+  '/wp-json/',
+  '/about/',
+  '/contact/',
+  '/subscribe/',
+  '/authors/',
+];
+
+function isEsgNewsArticleUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host !== 'esgnews.com' && !host.endsWith('.esgnews.com')) return false;
+  const path = parsed.pathname.toLowerCase();
+  if (ESG_INDEX_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
+  // Article permalinks are exactly one path segment under root (`/slug/`).
+  // Multi-segment paths (`/tag/x/`, `/esg-europe/page/12/`) are already
+  // rejected above; this catches future index types we haven't enumerated
+  // yet (e.g. a hypothetical `/topic/methane/`) without us having to keep
+  // maintaining the prefix list.
+  const segments = path.split('/').filter((segment) => segment.length > 0);
+  return segments.length === 1;
+}
+
+function isQuotaError(error: unknown): boolean {
+  return (
+    error instanceof FirecrawlError && (error.status === 402 || error.status === 429)
+  );
+}
 
 function isDuplicateOfCarbonPulse(title: string, cpTitles: readonly string[]): boolean {
   const lowerTitle = title.toLowerCase();
@@ -19,30 +75,24 @@ function isDuplicateOfCarbonPulse(title: string, cpTitles: readonly string[]): b
   });
 }
 
-async function searchAndExtract(
+async function discoverAndScrape(
   theme: ThemeConfig,
   processedUrls: ReadonlySet<string>,
   cpTitles: readonly string[],
   apiKey: string,
 ): Promise<RawArticle[]> {
-  const results = await firecrawlSearch(
-    `site:esgnews.com ${theme.esgNewsSearchTerms}`,
-    apiKey,
-    SEARCH_LIMIT,
-  );
+  // Hit ESG News's own WordPress search (default order: publish-date-desc)
+  // and read links straight from the markdown. This is what gives us
+  // recency — Firecrawl's `/v2/search` upstream index lacks dates on this
+  // publisher and binary-filtered every result when `tbs` was applied
+  // (PR #34 → reverted in #35; see firecrawl.helpers note).
+  const listingUrl = `${LISTING_URL_BASE}${encodeURIComponent(theme.esgNewsSearchTerms)}`;
+  const listing = await firecrawlScrape(listingUrl, apiKey);
 
-  const seen = new Set<string>();
-  const candidates = results.filter((result) => {
-    let hostname = '';
-    try {
-      hostname = new URL(result.url).hostname.toLowerCase();
-    } catch {
-      return false;
-    }
-    if (hostname !== 'esgnews.com' && !hostname.endsWith('.esgnews.com')) return false;
-    if (processedUrls.has(result.url) || seen.has(result.url)) return false;
-    if (isDuplicateOfCarbonPulse(result.title, cpTitles)) return false;
-    seen.add(result.url);
+  const candidates = extractMarkdownLinks(listing.markdown, ({ url, title }) => {
+    if (!isEsgNewsArticleUrl(url)) return false;
+    if (processedUrls.has(url)) return false;
+    if (isDuplicateOfCarbonPulse(title, cpTitles)) return false;
     return true;
   });
 
@@ -55,9 +105,18 @@ async function searchAndExtract(
       const scraped = await firecrawlScrape(candidate.url, apiKey);
       // No reliable publish date — skip rather than stamp it "today" and let a
       // stale article bypass the freshness window (parity with carbon-pulse.ts).
+      // Split the two failure modes so a Firecrawl metadata-schema regression
+      // (parseable string suddenly returning unparseable) is visibly distinct
+      // from publisher pages that genuinely lack a date.
+      if (!scraped.publishedTime) {
+        console.warn(`[ESG News] No publish_time metadata, skipping: ${candidate.url}`);
+        continue;
+      }
       const articleDate = parseDate(scraped.publishedTime);
       if (!articleDate) {
-        console.warn(`[ESG News] Missing/invalid publish date, skipping: ${candidate.url}`);
+        console.error(
+          `[ESG News] Unparseable publish_time "${scraped.publishedTime}", skipping: ${candidate.url}`,
+        );
         continue;
       }
       const ageMs = Date.now() - new Date(articleDate).getTime();
@@ -88,9 +147,10 @@ async function searchAndExtract(
       // Quota (402) / rate-limit (429): every remaining candidate would hit the
       // same wall. Stop scraping this theme but KEEP what was already collected
       // — throwing here would discard the partial `articles` for this theme.
-      if (error instanceof FirecrawlError && (error.status === 402 || error.status === 429)) {
+      if (isQuotaError(error)) {
+        const status = (error as FirecrawlError).status;
         console.error(
-          `[ESG News] Firecrawl ${error.status} (quota/rate limit) — aborting theme, keeping ${articles.length} collected`,
+          `[ESG News] Firecrawl ${status} (quota/rate limit) — aborting theme, keeping ${articles.length} collected`,
         );
         break;
       }
@@ -117,15 +177,23 @@ export async function scrapeEsgNews(
   // returned twice.
   const seenUrls = new Set(processedUrls);
   for (const theme of themes) {
-    console.log(`[ESG News] Searching: ${theme.name}`);
+    console.log(`[ESG News] Discovering: ${theme.name}`);
     try {
-      const articles = await searchAndExtract(theme, seenUrls, cpTitles, firecrawlApiKey);
+      const articles = await discoverAndScrape(theme, seenUrls, cpTitles, firecrawlApiKey);
       allArticles.push(...articles);
       for (const article of articles) seenUrls.add(article.url);
       console.log(`[ESG News] Found ${articles.length} articles for ${theme.name}`);
     } catch (error: unknown) {
+      // A 402/429 from the listing scrape itself (not the per-article scrape)
+      // propagates here; treat as quota exhaustion so the remaining themes
+      // don't hammer the exhausted API. Parity with `scrapeTrellis`.
+      if (isQuotaError(error)) {
+        const status = (error as FirecrawlError).status;
+        console.error(`[ESG News] Firecrawl ${status} during theme discovery — aborting remaining themes.`);
+        break;
+      }
       const message = error instanceof Error ? error.message : 'unknown';
-      console.error(`[ESG News] Search failed for "${theme.name}": ${message}`);
+      console.error(`[ESG News] Discovery failed for "${theme.name}": ${message}`);
     }
   }
   return allArticles;

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -12,30 +12,34 @@ const MAX_ARTICLE_AGE_DAYS = 30;
 const LISTING_URL_BASE = 'https://esgnews.com/?s=';
 
 // ESG News article permalinks are slug-only at the root (`/some-slug/`).
-// These prefixes mark tag/category/author/pagination/region/static-page
-// routes that the search page also links to — exclude them so we don't
-// waste credits scraping a non-article page (the old `/search` flow
-// burnt 16 scrapes on these in the 2026-05-19 validation run). All
-// entries end with `/` so they never accidentally swallow a real slug
-// (e.g. `/feed` would have excluded a legitimate `/feedback-policy/`).
-const ESG_INDEX_PATH_PREFIXES: readonly string[] = [
-  '/tag/',
-  '/category/',
-  '/author/',
-  '/page/',
-  '/esg-europe/',
-  '/esg-americas/',
-  '/esg-africa/',
-  '/esg-asia-pacific/',
-  '/feed/',
-  '/wp-admin/',
-  '/wp-content/',
-  '/wp-json/',
-  '/about/',
-  '/contact/',
-  '/subscribe/',
-  '/authors/',
-];
+// These first-path-segments mark tag/category/author/pagination/region/
+// static-page routes that the search page also links to — exclude them so
+// we don't waste credits scraping a non-article page (the old `/search`
+// flow burnt 16 scrapes on these in the 2026-05-19 validation run).
+//
+// Matching on the FIRST segment (not a prefix string) handles trailing-slash
+// variants uniformly: `/about`, `/about/`, and `/about/us/` all canonicalize
+// to first-segment `'about'`. The earlier prefix-list approach required
+// every entry to end with `/`, and a single missing slash silently let the
+// no-trailing-slash form through (cursor-bot finding on PR #36).
+const ESG_INDEX_FIRST_SEGMENTS: ReadonlySet<string> = new Set([
+  'tag',
+  'category',
+  'author',
+  'page',
+  'esg-europe',
+  'esg-americas',
+  'esg-africa',
+  'esg-asia-pacific',
+  'feed',
+  'wp-admin',
+  'wp-content',
+  'wp-json',
+  'about',
+  'contact',
+  'subscribe',
+  'authors',
+]);
 
 function isEsgNewsArticleUrl(url: string): boolean {
   let parsed: URL;
@@ -46,14 +50,13 @@ function isEsgNewsArticleUrl(url: string): boolean {
   }
   const host = parsed.hostname.toLowerCase();
   if (host !== 'esgnews.com' && !host.endsWith('.esgnews.com')) return false;
-  const path = parsed.pathname.toLowerCase();
-  if (ESG_INDEX_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
-  // Article permalinks are exactly one path segment under root (`/slug/`).
-  // Multi-segment paths (`/tag/x/`, `/esg-europe/page/12/`) are already
-  // rejected above; this catches future index types we haven't enumerated
-  // yet (e.g. a hypothetical `/topic/methane/`) without us having to keep
-  // maintaining the prefix list.
-  const segments = path.split('/').filter((segment) => segment.length > 0);
+  const segments = parsed.pathname.toLowerCase().split('/').filter((segment) => segment.length > 0);
+  if (segments.length === 0) return false;
+  if (ESG_INDEX_FIRST_SEGMENTS.has(segments[0]!)) return false;
+  // Article permalinks are exactly one segment under root (`/slug/`).
+  // Multi-segment paths (`/topic/methane/`, future index types) are
+  // rejected so we don't need to keep extending the exclusion set
+  // ahead of every CMS change.
   return segments.length === 1;
 }
 

--- a/apps/news-digest/pipeline/src/scraper/trellis.ts
+++ b/apps/news-digest/pipeline/src/scraper/trellis.ts
@@ -2,21 +2,25 @@ import { THEMES } from '../config.constants.js';
 import { curateTrellisArticles, type TrellisCandidate } from '../ai/trellis-curator.js';
 import { sanitizeArticleText } from '../helpers/content.helpers.js';
 import { parseDate } from '../helpers/date.helpers.js';
-import { FirecrawlError, firecrawlScrape, firecrawlSearch } from '../helpers/firecrawl.helpers.js';
+import {
+  FirecrawlError,
+  extractMarkdownLinks,
+  firecrawlScrape,
+} from '../helpers/firecrawl.helpers.js';
 import type { RawArticle, ThemeConfig } from '../types.js';
 
 const MAX_ARTICLES_PER_THEME = 1;
 const MAX_ARTICLE_AGE_DAYS = 30;
 const CANDIDATE_POOL_SIZE = 15;
-const SEARCH_LIMIT = 10;
-const MAX_EXCERPT_LENGTH = 400;
-// The curator (not a per-theme query) decides which of these are worth the
-// digest; keep the discovery query broad and recency-biased, scoped to Trellis.
-const CURATION_QUERY = 'site:trellis.net climate sustainability decarbonization circular economy';
+const PER_THEME_LISTING_URL_BASE = 'https://trellis.net/?s=';
+// Trellis's own date-ordered articles index — same URL the pre-Firecrawl
+// Playwright scraper used as `LISTING_URL` for the curation broad pool.
+// One scrape per pipeline run, shared across all eligible themes.
+const CURATION_LISTING_URL = 'https://trellis.net/articles/';
 
 // Trellis articles live at trellis.net/article/...; the old Playwright code only
 // ever followed `a[href*="/article/"]`. Require both an in-domain host and the
-// article path so a search provider can't steer us to an arbitrary URL.
+// article path so a listing-page menu/footer link can't steer us elsewhere.
 function isTrellisArticleUrl(url: string): boolean {
   let parsed: URL;
   try {
@@ -26,7 +30,10 @@ function isTrellisArticleUrl(url: string): boolean {
   }
   const host = parsed.hostname.toLowerCase();
   if (host !== 'trellis.net' && !host.endsWith('.trellis.net')) return false;
-  return parsed.pathname.includes('/article/');
+  // Lowercase the path before the contains-check so a future CMS migration
+  // serving `/Article/` (or otherwise mixed-case) doesn't silently lose
+  // every candidate; parity with the ESG predicate above.
+  return parsed.pathname.toLowerCase().includes('/article/');
 }
 
 function isQuotaError(error: unknown): boolean {
@@ -50,9 +57,17 @@ async function scrapeArticle(
   const scraped = await firecrawlScrape(url, apiKey);
   // No reliable publish date — skip rather than stamp it "today" and let a
   // stale article bypass the freshness window (parity with esg/carbon-pulse).
+  // Split missing-vs-unparseable so a Firecrawl metadata-schema regression
+  // is visibly distinct from publisher pages that genuinely lack a date.
+  if (!scraped.publishedTime) {
+    console.warn(`[Trellis] No publish_time metadata, skipping: ${url}`);
+    return null;
+  }
   const articleDate = parseDate(scraped.publishedTime);
   if (!articleDate) {
-    console.warn(`[Trellis] Missing/invalid publish date, skipping: ${url}`);
+    console.error(
+      `[Trellis] Unparseable publish_time "${scraped.publishedTime}", skipping: ${url}`,
+    );
     return null;
   }
   const ageMs = Date.now() - new Date(articleDate).getTime();
@@ -78,27 +93,26 @@ async function scrapeArticle(
   };
 }
 
-interface ThemeSearchResult {
+interface ThemeDiscoveryResult {
   readonly articles: RawArticle[];
   readonly quotaExhausted: boolean;
 }
 
-async function searchTheme(
+async function discoverThemeAndScrape(
   theme: ThemeConfig,
   processedUrls: ReadonlySet<string>,
   apiKey: string,
-): Promise<ThemeSearchResult> {
-  const results = await firecrawlSearch(
-    `site:trellis.net ${theme.trellisSearchTerms}`,
-    apiKey,
-    SEARCH_LIMIT,
-  );
+): Promise<ThemeDiscoveryResult> {
+  // Per-theme discovery: Trellis's own WordPress search (default
+  // publish-date-desc ordering), then extract `/article/` permalinks from
+  // the returned markdown. Replaces the `/v2/search` flow whose upstream
+  // index lacked dates for this publisher.
+  const listingUrl = `${PER_THEME_LISTING_URL_BASE}${encodeURIComponent(theme.trellisSearchTerms)}`;
+  const listing = await firecrawlScrape(listingUrl, apiKey);
 
-  const seen = new Set<string>();
-  const candidates = results.filter((result) => {
-    if (!isTrellisArticleUrl(result.url)) return false;
-    if (processedUrls.has(result.url) || seen.has(result.url)) return false;
-    seen.add(result.url);
+  const candidates = extractMarkdownLinks(listing.markdown, ({ url }) => {
+    if (!isTrellisArticleUrl(url)) return false;
+    if (processedUrls.has(url)) return false;
     return true;
   });
 
@@ -127,26 +141,28 @@ async function collectCandidates(
   excludeUrls: ReadonlySet<string>,
   apiKey: string,
 ): Promise<TrellisCandidate[]> {
-  // Over-request: host/exclude/dedup filtering below would otherwise shrink the
-  // pool below CANDIDATE_POOL_SIZE with no top-up.
-  const results = await firecrawlSearch(CURATION_QUERY, apiKey, CANDIDATE_POOL_SIZE * 2);
-  const seen = new Set<string>();
-  const candidates: TrellisCandidate[] = [];
-  for (const result of results) {
-    if (!isTrellisArticleUrl(result.url)) continue;
-    if (excludeUrls.has(result.url) || seen.has(result.url)) continue;
-    seen.add(result.url);
-    // date is enforced later at the pick scrape; the curator ranks on
-    // title+excerpt and only prefers recency "when relevance is similar".
-    candidates.push({
-      url: result.url,
-      title: result.title,
-      date: '',
-      excerpt: (result.description || result.title).slice(0, MAX_EXCERPT_LENGTH),
-    });
-    if (candidates.length >= CANDIDATE_POOL_SIZE) break;
-  }
-  return candidates;
+  // Single broad-pool scrape per run; shared across all themes via the curator.
+  const listing = await firecrawlScrape(CURATION_LISTING_URL, apiKey);
+  // Over-request: host/exclude/dedup filtering would otherwise shrink the pool
+  // below CANDIDATE_POOL_SIZE with no top-up. extractMarkdownLinks already
+  // dedupes URLs preserving order, so the predicate just enforces host/path
+  // and the running exclude set.
+  const links = extractMarkdownLinks(listing.markdown, ({ url }) => {
+    if (!isTrellisArticleUrl(url)) return false;
+    if (excludeUrls.has(url)) return false;
+    return true;
+  });
+  // Cap the pool to twice CANDIDATE_POOL_SIZE so the curator has headroom
+  // to reject low-quality candidates without us re-querying.
+  return links.slice(0, CANDIDATE_POOL_SIZE * 2).map((link) => ({
+    url: link.url,
+    title: link.title,
+    // Markdown extraction doesn't expose the listing card's excerpt the old
+    // Playwright code did; fall back to the title (matches the curator
+    // contract — it just wants enough signal to rank).
+    date: '',
+    excerpt: link.title,
+  }));
 }
 
 export async function scrapeTrellis(
@@ -166,9 +182,9 @@ export async function scrapeTrellis(
   const seenUrls = new Set(processedUrls);
   let quotaExhausted = false;
   for (const theme of themes) {
-    console.log(`[Trellis] Searching: ${theme.name}`);
+    console.log(`[Trellis] Discovering: ${theme.name}`);
     try {
-      const result = await searchTheme(theme, seenUrls, firecrawlApiKey);
+      const result = await discoverThemeAndScrape(theme, seenUrls, firecrawlApiKey);
       perTheme.push(...result.articles);
       for (const article of result.articles) seenUrls.add(article.url);
       console.log(`[Trellis] Found ${result.articles.length} article(s) for ${theme.name}`);
@@ -177,16 +193,16 @@ export async function scrapeTrellis(
         break;
       }
     } catch (error: unknown) {
-      // A 402/429 from firecrawlSearch itself (not the scrape) propagates here;
-      // treat it as quota exhaustion too, so remaining themes + curation are
-      // skipped rather than hammering the exhausted API.
+      // A 402/429 from the listing scrape itself (not the article scrape)
+      // propagates here; treat it as quota exhaustion too, so remaining
+      // themes + curation are skipped rather than hammering the exhausted API.
       if (isQuotaError(error)) {
-        console.error('[Trellis] Firecrawl quota/rate limit during theme search — aborting remaining themes.');
+        console.error('[Trellis] Firecrawl quota/rate limit during theme discovery — aborting remaining themes.');
         quotaExhausted = true;
         break;
       }
       const message = error instanceof Error ? error.message : 'unknown';
-      console.error(`[Trellis] Search failed for "${theme.name}": ${message}`);
+      console.error(`[Trellis] Discovery failed for "${theme.name}": ${message}`);
     }
   }
 


### PR DESCRIPTION
### Summary

Replace Firecrawl `/v2/search` (Google-style web index) with Firecrawl `/v2/scrape` of each publisher's own date-ordered WordPress search / articles listing, then parse article links out of the returned markdown. Recovers the recency the old Playwright scrapers had for free.

### Why

The 2026-05-19 validations exposed two coupled failures of the previous discovery layer:

1. **Default `/v2/search` returns mostly stale results** for these publishers. 16-theme validation: 4 ESG + 3 Trellis articles (~270 cr burned, mostly on candidates that the per-scraper freshness filter then rejected as "too old").
2. **`tbs=qdr:m` recency parameter is binary-fatal** (PR #34, reverted in PR #35). Direct A/B probe against the Firecrawl API:

| Query | without `tbs` | with `tbs=qdr:m` |
|---|---|---|
| `site:esgnews.com methane superpollutant` | 9 results | **0** |
| `site:trellis.net methane superpollutant refrigerant` | 10 results | **0** |

Firecrawl honors `tbs` only when its upstream index carries a clean publish date per hit. Neither publisher does. Same failure mode for `qdr:y` / custom `cdr` ranges.

The old Playwright code never went through that index — it hit each site's own WordPress search page (default sort: date-desc) and read date-ordered links straight from the HTML. This PR replicates that flow via Firecrawl `scrape`, so we keep the Cloudflare bypass + selector-rot resilience without the recency regression.

### Discovery flow

```
ESG News      listing = https://esgnews.com/?s=<encoded terms>          (1 cr / theme)
Trellis       listing = https://trellis.net/?s=<encoded terms>          (1 cr / theme)
Trellis       curation pool = https://trellis.net/articles/             (1 cr / run, shared)
```

### New helper

`firecrawl.helpers.extractMarkdownLinks(markdown, predicate)` — parses inline `[title](url)` links from any markdown, deduping by URL preserving order. Rejects image syntax (`![alt](url)`) via a `(?<!!)` lookbehind so listing-card thumbnails do not waste scrapes. Per-source predicates (`isEsgNewsArticleUrl`, `isTrellisArticleUrl`) live next to each scraper.

### Cost model

| Scope | Listing | Article | ≈ cr |
|---|---|---|---|
| 1 theme (THEMES_FILTER) | 3 | ≤ 6 | ~9–11 |
| 5 daily | 11 | ≤ 20 | ~30–35 |
| 16 themes | 33 | ≤ 53 | ~85–100 |

Down from ~270 cr on the same 16-theme test before this PR — most of the savings come from cheap listing-scrapes vs `/search`+per-candidate scrape-then-reject.

### bmad-quick-dev review patches included

| # | Origin (3-agent review) | Patch |
|---|---|---|
| P1 | code-rev #3 · silent-fail #3 · pr-test B1 | ESG listing 402/429 → break the theme loop (parity with Trellis) |
| P2 | code-rev #2 · pr-test B2 | `extractMarkdownLinks` rejects `![alt](url)` |
| P3 | code-rev #4 · silent-fail #2 · pr-test B3 | ESG predicate: 16 prefixes + depth-1 segment safety net + wp-admin/wp-content/wp-json/about/contact/subscribe/authors and sibling regions |
| P4 | silent-fail #10 | Trellis pathname lowercased before `/article/` check |
| P5 | code-rev #5, #10 | Dead `MAX_EXCERPT_LENGTH` constant removed; misleading comment corrected |
| P6 | silent-fail #4 | Split logs: `No publish_time metadata` (warn) vs `Unparseable publish_time` (error) |
| P7 | silent-fail #5 | `FirecrawlError` preserves `.cause` so transport class survives wrapping |
| P8 | code-rev #7 | Restored "Validated against the v2 API in the 2026-05-18 Step 0 spike" operational note |
| P9 | code-rev #9 | `ThemeSearchResult` → `ThemeDiscoveryResult` for rename parity |
| P10 | pr-test M1–M3 | Tests: 429 parametrization (it.each), WP-* + static-page coverage, depth-1 safety net, fill-cap Trellis, curator-throws, listing 402 ESG, image-syntax rejection, cause preserved |

### Tests

**190 pass** (baseline 172 + 18 new across `firecrawl.helpers.spec.ts`, `esg-news.spec.ts`, `trellis.spec.ts`). Mock surface moved from `/v2/search`+`/v2/scrape` to `/v2/scrape`-only; `installFetch` now fails loudly on any other endpoint so a regression that reintroduces a `/v2/search` call breaks the tests instead of silently returning data.

### Validation plan (post-merge)

1. Rebuild `firecrawl-validation` image from new main.
2. Isolated ECS run with `THEMES_FILTER="Methane & Super Pollutants"` (this theme returned **0 ESG + 0 Trellis** in both prior validation paths — non-zero now is the proof). DRY_RUN=true, throwaway S3 prefix. Expected cost: ~10 cr.
3. Inspect CloudWatch — listing scrape OK, candidates non-zero, at least one ESG or Trellis article returned with clean date + sanitized body.
4. Only if green → rebuild `:latest` and ship.

### Production safety

Prod `:latest` was never rebuilt against #34 / #35 — production still runs the pre-#31 code. This PR does not change deployment. The isolated validation runs above the `:latest` tag.

### Related links

- Spec: `apps/news-digest/_bmad-output/implementation-artifacts/spec-firecrawl-hybrid-discovery.md`
- Memory: `news-digest-firecrawl-decision`
- Previous PRs: #31 (ESG migration), #32 (Trellis migration), #33 (infra), #34 (tbs + THEMES_FILTER), #35 (tbs revert)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the discovery mechanism for ESG News and Trellis from `/v2/search` to scraping publisher listing pages, which can affect article selection/coverage and Firecrawl credit usage; also adjusts quota/transport error handling paths that impact pipeline control flow.
> 
> **Overview**
> **Discovery is reworked to restore recency:** ESG News and Trellis now discover candidates by `firecrawlScrape`-ing each publisher’s own WordPress search/listing pages and extracting inline markdown links, instead of using Firecrawl `/v2/search`.
> 
> **New shared helper + stricter filtering:** adds `extractMarkdownLinks` (dedupe, predicate filtering, ignores images) and updates ESG/Trellis URL predicates (ESG first-segment exclusions + depth-1 slug rule; Trellis case-insensitive `/article/` check). Quota/rate-limit handling is tightened (treat 402/429 during listing discovery as exhaustion; distinguish missing vs unparseable publish dates), `FirecrawlError` now preserves the underlying `cause`, and tests are updated/expanded while removing `firecrawlSearch` coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714365d388ac4ad724e9d2c74cd8edd5591b5694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->