### PR TITLE
Fix ESG News discovery: use RSS feed instead of broken search

### DIFF
--- a/apps/news-digest/pipeline/src/ai/__tests__/article-curator.spec.ts
+++ b/apps/news-digest/pipeline/src/ai/__tests__/article-curator.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { curateTrellisArticles, type TrellisCandidate } from '../trellis-curator.js';
+import { curateArticles, type ArticleCandidate } from '../article-curator.js';
 
 const THEME_NAMES = ['Methane & Super Pollutants', 'Circularity & Composting', 'Carbon Markets'];
 
-function stubCandidate(overrides: Partial<TrellisCandidate> = {}): TrellisCandidate {
+function stubCandidate(overrides: Partial<ArticleCandidate> = {}): ArticleCandidate {
   return {
     url: 'https://trellis.net/article/default/',
     title: 'Default Title',
@@ -27,7 +27,7 @@ function anthropicText(rawText: string): Response {
   return new Response(body, { status: 200, headers: { 'content-type': 'application/json' } });
 }
 
-describe('curateTrellisArticles', () => {
+describe('curateArticles', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
   });
@@ -38,7 +38,7 @@ describe('curateTrellisArticles', () => {
   });
 
   it('returns empty array without calling the API when candidates are empty', async () => {
-    const result = await curateTrellisArticles([], THEME_NAMES, 'test-key');
+    const result = await curateArticles([], THEME_NAMES, 'test-key');
     expect(result).toEqual([]);
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
@@ -54,7 +54,7 @@ describe('curateTrellisArticles', () => {
         { url: 'https://trellis.net/article/b/', mainTheme: 'Methane & Super Pollutants', reason: 'ok' },
       ]),
     );
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([
       { url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets' },
       { url: 'https://trellis.net/article/b/', mainTheme: 'Methane & Super Pollutants' },
@@ -69,7 +69,7 @@ describe('curateTrellisArticles', () => {
         { url: 'https://evil.example/', mainTheme: 'Carbon Markets', reason: 'bad' },
       ]),
     );
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([{ url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets' }]);
   });
 
@@ -80,11 +80,11 @@ describe('curateTrellisArticles', () => {
         { url: 'https://trellis.net/article/a/', mainTheme: 'Bogus Theme', reason: 'x' },
       ]),
     );
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([]);
   });
 
-  it('caps picks at MAX_PICKS (2)', async () => {
+  it('caps picks at the default maxPicks (2)', async () => {
     const candidates = [
       stubCandidate({ url: 'https://trellis.net/article/a/' }),
       stubCandidate({ url: 'https://trellis.net/article/b/' }),
@@ -97,37 +97,70 @@ describe('curateTrellisArticles', () => {
         { url: 'https://trellis.net/article/c/', mainTheme: 'Carbon Markets', reason: '3' },
       ]),
     );
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toHaveLength(2);
+  });
+
+  it('honors an explicit maxPicks option', async () => {
+    const candidates = ['a', 'b', 'c', 'd', 'e'].map((slug) =>
+      stubCandidate({ url: `https://esgnews.com/${slug}/` }),
+    );
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicResponse(
+        candidates.map((candidate) => ({
+          url: candidate.url, mainTheme: 'Carbon Markets', reason: 'ok',
+        })),
+      ),
+    );
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key', { maxPicks: 3 });
+    expect(result).toHaveLength(3);
+  });
+
+  it('drops a pick whose URL is repeated so the same article is not curated twice', async () => {
+    const candidates = [stubCandidate({ url: 'https://esgnews.com/a/' })];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      anthropicResponse([
+        { url: 'https://esgnews.com/a/', mainTheme: 'Carbon Markets', reason: 'first' },
+        { url: 'https://esgnews.com/a/', mainTheme: 'Methane & Super Pollutants', reason: 'dup' },
+      ]),
+    );
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key', { maxPicks: 3 });
+    expect(result).toEqual([{ url: 'https://esgnews.com/a/', mainTheme: 'Carbon Markets' }]);
+  });
+
+  it('uses the label option in log output', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const candidates = [stubCandidate({ url: 'https://esgnews.com/a/' })];
+    vi.mocked(fetch).mockResolvedValueOnce(anthropicResponse([]));
+    await curateArticles(candidates, THEME_NAMES, 'test-key', { label: 'ESG News Curator' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[ESG News Curator]'));
   });
 
   it('returns empty array when Claude returns non-JSON text', async () => {
     const candidates = [stubCandidate()];
     vi.mocked(fetch).mockResolvedValueOnce(anthropicText('not json at all'));
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([]);
   });
 
   it('returns empty array when Claude returns JSON missing the picks field', async () => {
     const candidates = [stubCandidate()];
     vi.mocked(fetch).mockResolvedValueOnce(anthropicText(JSON.stringify({ other: 'field' })));
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([]);
   });
 
   it('returns empty array when fetch rejects', async () => {
     const candidates = [stubCandidate()];
     vi.mocked(fetch).mockRejectedValueOnce(new Error('network down'));
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([]);
   });
 
   it('returns empty array when fetch returns non-2xx status', async () => {
     const candidates = [stubCandidate()];
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response('error', { status: 500 }),
-    );
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    vi.mocked(fetch).mockResolvedValueOnce(new Response('error', { status: 500 }));
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([]);
   });
 
@@ -136,7 +169,7 @@ describe('curateTrellisArticles', () => {
     const abortError = new Error('The operation was aborted');
     abortError.name = 'AbortError';
     vi.mocked(fetch).mockRejectedValueOnce(abortError);
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([]);
   });
 
@@ -147,7 +180,7 @@ describe('curateTrellisArticles', () => {
         { url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets', reason: 'ok' },
       ]),
     );
-    await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    await curateArticles(candidates, THEME_NAMES, 'test-key');
     const [, init] = vi.mocked(fetch).mock.calls[0]!;
     expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
@@ -157,7 +190,7 @@ describe('curateTrellisArticles', () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       anthropicText('```json\n{"picks":[{"url":"https://trellis.net/article/a/","mainTheme":"Carbon Markets","reason":"ok"}]}\n```'),
     );
-    const result = await curateTrellisArticles(candidates, THEME_NAMES, 'test-key');
+    const result = await curateArticles(candidates, THEME_NAMES, 'test-key');
     expect(result).toEqual([{ url: 'https://trellis.net/article/a/', mainTheme: 'Carbon Markets' }]);
   });
 });

--- a/apps/news-digest/pipeline/src/ai/article-curator.ts
+++ b/apps/news-digest/pipeline/src/ai/article-curator.ts
@@ -1,11 +1,16 @@
+// Shared article curator — picks the most digest-worthy articles from a
+// candidate pool and assigns each an allowed theme. Source-agnostic: Trellis
+// (broad `/articles/` index pool) and ESG News (RSS feed pool) both feed it.
+// The `label` option only changes log prefixes; `maxPicks` bounds the result.
+
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const ANTHROPIC_VERSION = '2023-06-01';
 const MODEL = 'claude-haiku-4-5-20251001';
-const MAX_TOKENS = 512;
-const MAX_PICKS = 2;
+const MAX_TOKENS = 1024;
+const DEFAULT_MAX_PICKS = 2;
 const FETCH_TIMEOUT_MS = 15_000;
 
-export interface TrellisCandidate {
+export interface ArticleCandidate {
   readonly url: string;
   readonly title: string;
   readonly date: string;
@@ -17,23 +22,38 @@ export interface CuratedPick {
   readonly mainTheme: string;
 }
 
+export interface CurateOptions {
+  // Upper bound on accepted picks. Defaults to 2 (the original Trellis cap).
+  readonly maxPicks?: number;
+  // Log-prefix label, e.g. 'Trellis Curator' / 'ESG News Curator'.
+  readonly label?: string;
+}
+
 interface PickWithReason {
   readonly url: string;
   readonly mainTheme: string;
   readonly reason: string;
 }
 
-const SYSTEM_PROMPT =
-  'You curate a daily sustainability and climate newsletter for the Carrot Foundation, ' +
-  'a Web3 impact platform focused on decarbonization, methane reduction, circular economy, ' +
-  'and tokenized environmental credits. Pick the 2 articles most valuable to a decarbonization ' +
-  'and circularity audience. Prefer original reporting over opinion pieces. Prefer more recent ' +
-  'articles when relevance is similar. Avoid picking two articles that cover the same story.';
+function buildSystemPrompt(maxPicks: number): string {
+  return (
+    'You curate a daily sustainability and climate newsletter for the Carrot Foundation, ' +
+    'a Web3 impact platform focused on decarbonization, methane reduction, circular economy, ' +
+    `and tokenized environmental credits. Pick the ${maxPicks} articles most valuable to a ` +
+    'decarbonization and circularity audience. Prefer original reporting over opinion pieces. ' +
+    'Prefer more recent articles when relevance is similar. Avoid picking multiple articles ' +
+    'that cover the same story.'
+  );
+}
 
-function buildUserPrompt(candidates: readonly TrellisCandidate[], themeNames: readonly string[]): string {
+function buildUserPrompt(
+  candidates: readonly ArticleCandidate[],
+  themeNames: readonly string[],
+  maxPicks: number,
+): string {
   const payload = {
-    candidates: candidates.map((c) => ({
-      url: c.url, title: c.title, date: c.date, excerpt: c.excerpt,
+    candidates: candidates.map((candidate) => ({
+      url: candidate.url, title: candidate.title, date: candidate.date, excerpt: candidate.excerpt,
     })),
     allowedThemes: themeNames,
   };
@@ -45,7 +65,7 @@ Return ONLY JSON with this shape, no markdown, no commentary:
 - "url" must exactly match one of the candidate URLs.
 - "mainTheme" must exactly match one of the allowed theme names.
 - "reason" is a short rationale (<= 200 chars).
-- Return at most 2 picks.`;
+- Return at most ${maxPicks} picks.`;
 }
 
 function parseClaudeText(rawText: string): unknown {
@@ -61,12 +81,15 @@ function validatePicks(
   raw: unknown,
   candidateUrls: ReadonlySet<string>,
   themeNames: ReadonlySet<string>,
+  maxPicks: number,
+  label: string,
 ): readonly CuratedPick[] {
   if (!raw || typeof raw !== 'object') return [];
   const picks = (raw as Record<string, unknown>)['picks'];
   if (!Array.isArray(picks)) return [];
 
   const validated: CuratedPick[] = [];
+  const seen = new Set<string>();
   for (const entry of picks) {
     if (!entry || typeof entry !== 'object') continue;
     const pick = entry as Record<string, unknown>;
@@ -74,11 +97,13 @@ function validatePicks(
     const mainTheme = pick['mainTheme'];
     if (typeof url !== 'string' || typeof mainTheme !== 'string') continue;
     if (!candidateUrls.has(url) || !themeNames.has(mainTheme)) {
-      console.warn(`[Trellis Curator] Dropped invalid pick: url=${url} mainTheme=${mainTheme}`);
+      console.warn(`[${label}] Dropped invalid pick: url=${url} mainTheme=${mainTheme}`);
       continue;
     }
+    if (seen.has(url)) continue;
+    seen.add(url);
     validated.push({ url, mainTheme });
-    if (validated.length >= MAX_PICKS) break;
+    if (validated.length >= maxPicks) break;
   }
   return validated;
 }
@@ -87,26 +112,37 @@ function logPicks(
   picks: readonly CuratedPick[],
   rawPicks: readonly PickWithReason[],
   candidateCount: number,
+  maxPicks: number,
+  label: string,
 ): void {
-  console.log(`[Trellis Curator] Candidates: ${candidateCount}, Picks accepted: ${picks.length}`);
+  console.log(`[${label}] Candidates: ${candidateCount}, Picks accepted: ${picks.length}`);
   for (const pick of picks) {
-    const match = rawPicks.find((p) => p.url === pick.url);
+    const match = rawPicks.find((rawPick) => rawPick.url === pick.url);
     const reason = match?.reason ?? '';
-    console.log(`[Trellis Curator] Pick: ${pick.url} (theme: ${pick.mainTheme}, reason: ${reason})`);
+    console.log(`[${label}] Pick: ${pick.url} (theme: ${pick.mainTheme}, reason: ${reason})`);
   }
-  if (picks.length < MAX_PICKS) {
-    console.warn(`[Trellis Curator] Fewer than ${MAX_PICKS} picks survived validation (got ${picks.length}).`);
+  if (picks.length < maxPicks) {
+    console.warn(`[${label}] Fewer than ${maxPicks} picks survived validation (got ${picks.length}).`);
   }
 }
 
-export async function curateTrellisArticles(
-  candidates: readonly TrellisCandidate[],
+/**
+ * Ask Claude to pick the most digest-worthy articles from `candidates` and tag
+ * each with one of `themeNames`. Returns at most `maxPicks` picks; any failure
+ * (network, non-2xx, malformed JSON, timeout) degrades to an empty array so the
+ * caller falls back to whatever it collected without the curator.
+ */
+export async function curateArticles(
+  candidates: readonly ArticleCandidate[],
   themeNames: readonly string[],
   anthropicApiKey: string,
+  options: CurateOptions = {},
 ): Promise<readonly CuratedPick[]> {
   if (candidates.length === 0) return [];
 
-  const candidateUrls = new Set(candidates.map((c) => c.url));
+  const maxPicks = options.maxPicks ?? DEFAULT_MAX_PICKS;
+  const label = options.label ?? 'Curator';
+  const candidateUrls = new Set(candidates.map((candidate) => candidate.url));
   const themeNameSet = new Set(themeNames);
 
   let response: Response;
@@ -124,8 +160,8 @@ export async function curateTrellisArticles(
       body: JSON.stringify({
         model: MODEL,
         max_tokens: MAX_TOKENS,
-        system: SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: buildUserPrompt(candidates, themeNames) }],
+        system: buildSystemPrompt(maxPicks),
+        messages: [{ role: 'user', content: buildUserPrompt(candidates, themeNames, maxPicks) }],
       }),
     });
   } catch (error: unknown) {
@@ -133,14 +169,14 @@ export async function curateTrellisArticles(
     const message = isAbort
       ? `timeout after ${FETCH_TIMEOUT_MS}ms`
       : (error instanceof Error ? error.message : 'unknown');
-    console.error(`[Trellis Curator] fetch failed: ${message}`);
+    console.error(`[${label}] fetch failed: ${message}`);
     return [];
   } finally {
     clearTimeout(timeoutId);
   }
 
   if (!response.ok) {
-    console.error(`[Trellis Curator] API returned ${response.status}`);
+    console.error(`[${label}] API returned ${response.status}`);
     return [];
   }
 
@@ -149,7 +185,7 @@ export async function curateTrellisArticles(
     data = (await response.json()) as Record<string, unknown>;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'unknown';
-    console.error(`[Trellis Curator] invalid response body: ${message}`);
+    console.error(`[${label}] invalid response body: ${message}`);
     return [];
   }
 
@@ -157,26 +193,26 @@ export async function curateTrellisArticles(
   const firstBlock = content[0] as Record<string, unknown> | undefined;
   const rawText = typeof firstBlock?.['text'] === 'string' ? firstBlock['text'] : '';
   if (!rawText) {
-    console.error('[Trellis Curator] empty content in response');
+    console.error(`[${label}] empty content in response`);
     return [];
   }
 
   const parsed = parseClaudeText(rawText);
-  const validated = validatePicks(parsed, candidateUrls, themeNameSet);
+  const validated = validatePicks(parsed, candidateUrls, themeNameSet, maxPicks, label);
 
   const rawPicks: PickWithReason[] = [];
   if (parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>)['picks'])) {
     const rawList = (parsed as Record<string, unknown>)['picks'] as unknown[];
     for (const entry of rawList) {
       if (entry && typeof entry === 'object') {
-        const e = entry as Record<string, unknown>;
-        if (typeof e['url'] === 'string' && typeof e['mainTheme'] === 'string' && typeof e['reason'] === 'string') {
-          rawPicks.push({ url: e['url'], mainTheme: e['mainTheme'], reason: e['reason'] });
+        const pick = entry as Record<string, unknown>;
+        if (typeof pick['url'] === 'string' && typeof pick['mainTheme'] === 'string' && typeof pick['reason'] === 'string') {
+          rawPicks.push({ url: pick['url'], mainTheme: pick['mainTheme'], reason: pick['reason'] });
         }
       }
     }
   }
 
-  logPicks(validated, rawPicks, candidates.length);
+  logPicks(validated, rawPicks, candidates.length, maxPicks, label);
   return validated;
 }

--- a/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
+++ b/apps/news-digest/pipeline/src/helpers/firecrawl.helpers.ts
@@ -1,15 +1,17 @@
-// Thin Firecrawl v2 HTTP client (scrape) used by the scrapers.
+// Thin Firecrawl v2 HTTP client (scrape) used by the Trellis scraper.
 //
 // Firecrawl replaces hand-written CSS-selector scraping: `scrape` returns
 // markdown regardless of DOM, and we discover article candidates by
-// scraping each publisher's own date-ordered listing/search page and
+// scraping Trellis's own `/articles/` index + `?s=` search pages and
 // extracting links from that markdown.
 //
 // Why not `/v2/search`? It was tried (PRs #31/#32) and failed: the upstream
-// web index does not carry reliable publish dates for `esgnews.com` /
-// `trellis.net`, so its `tbs=qdr:*` recency filter is binary-fatal (PR #34
-// → reverted in #35). Hitting each publisher's own search/listing page
-// gives the same recency the old Playwright scrapers had for free.
+// web index does not carry reliable publish dates for `trellis.net`, so its
+// `tbs=qdr:*` recency filter is binary-fatal (PR #34 → reverted in #35).
+//
+// ESG News no longer uses this client at all: `esgnews.com/?s=` turned out to
+// ignore the query term and `orderby` entirely (validated 2026-05-21), so the
+// ESG scraper switched to the publisher RSS feed — see `scraper/esg-news.ts`.
 //
 // Mirrors the raw-`fetch` pattern in `ai/article-processor.ts` (no SDK).
 // Validated against the v2 API in the 2026-05-18 Step 0 spike and the

--- a/apps/news-digest/pipeline/src/orchestrator.ts
+++ b/apps/news-digest/pipeline/src/orchestrator.ts
@@ -252,7 +252,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     console.log('Step 4: Scraping ESG News...');
     try {
       const cpTitles = cpArticles.map((article) => article.title);
-      esgArticles = await scrapeEsgNews(eligibleThemes, processedUrls, cpTitles, config.secrets.firecrawlApiKey);
+      esgArticles = await scrapeEsgNews(processedUrls, cpTitles, config.secrets.anthropicApiKey);
       console.log(`ESG News: ${esgArticles.length} articles`);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : 'unknown';

--- a/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/esg-news.spec.ts
@@ -1,67 +1,69 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import type { ThemeConfig } from '../../types.js';
 import { scrapeEsgNews } from '../esg-news.js';
 
-const KEY = 'fc-test-key';
+const FEED_URL = 'https://esgnews.com/feed/';
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const KEY = 'anthropic-test-key';
 
-function stubTheme(overrides: Partial<ThemeConfig> = {}): ThemeConfig {
-  return {
-    name: 'Carbon Markets',
-    frequency: 'daily',
-    carbonPulseSearchTerms: 'carbon market',
-    esgNewsSearchTerms: 'carbon market',
-    trellisSearchTerms: 'carbon market',
-    ...overrides,
-  };
+function rfc822(daysAgo: number): string {
+  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toUTCString();
 }
 
-function daysAgoIso(days: number): string {
-  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+interface FeedItemInput {
+  readonly title: string;
+  readonly link: string;
+  readonly daysAgo?: number;
+  readonly pubDate?: string;
+  readonly creator?: string;
+  readonly description?: string;
+  readonly content?: string;
 }
 
-function listingUrl(theme: ThemeConfig): string {
-  return `https://esgnews.com/?s=${encodeURIComponent(theme.esgNewsSearchTerms)}`;
+function feedXml(items: readonly FeedItemInput[]): string {
+  const body = items
+    .map((item) => {
+      const pubDate = item.pubDate ?? rfc822(item.daysAgo ?? 2);
+      return `<item>
+  <title><![CDATA[${item.title}]]></title>
+  <link>${item.link}</link>
+  <pubDate>${pubDate}</pubDate>
+  <dc:creator><![CDATA[${item.creator ?? 'ESG News'}]]></dc:creator>
+  <description><![CDATA[${item.description ?? 'An excerpt.'}]]></description>
+  <content:encoded><![CDATA[${item.content ?? '<p>A full ESG News article body about climate policy and methane.</p>'}]]></content:encoded>
+</item>`;
+    })
+    .join('\n');
+  return `<?xml version="1.0"?><rss><channel><title>ESG News</title>${body}</channel></rss>`;
 }
-
-/** Synthesize a listing-page markdown body from a set of links. */
-function listingMarkdown(links: ReadonlyArray<{ url: string; title: string }>): string {
-  return links.map(({ url, title }) => `[${title}](${url})`).join('\n');
-}
-
-type ScrapeEntry =
-  | { markdown: string; publishedTime?: string; author?: string }
-  | { status: number };
 
 /**
- * Mock every Firecrawl `/v2/scrape` call (both listing-page discovery and
- * per-article scraping). Listing URLs and article URLs are siblings in the
- * `scrapes` map; absence falls through to a 404.
+ * Route GET (the RSS feed) and POST (the curator's Anthropic call). The curator
+ * mock echoes back a pick for every candidate URL in `pickedUrls`; when
+ * `pickedUrls` is undefined it picks every candidate it was given.
  */
-function installFetch(scrapes: Record<string, ScrapeEntry>): void {
+function installFetch(xml: string, pickedUrls?: readonly string[]): void {
   vi.stubGlobal(
     'fetch',
-    vi.fn(async (url: string, init: { body: string }) => {
-      if (!url.endsWith('/v2/scrape')) {
-        throw new Error(`Unexpected fetch URL ${url} — only /v2/scrape is mocked`);
+    vi.fn(async (url: string, init?: { body?: string }) => {
+      if (url === FEED_URL) {
+        return { ok: true, status: 200, text: async () => xml };
       }
-      const body = JSON.parse(init.body) as { url?: string };
-      const entry = scrapes[body.url ?? ''];
-      if (!entry || 'status' in entry) {
-        return { ok: false, status: entry ? entry.status : 404, json: async () => ({}) };
+      if (url === ANTHROPIC_URL) {
+        const payload = JSON.parse(init?.body ?? '{}') as { messages: Array<{ content: string }> };
+        const userPrompt = payload.messages[0]!.content;
+        const candidates = (JSON.parse(userPrompt.slice(0, userPrompt.indexOf('\n\n'))) as {
+          candidates: Array<{ url: string }>;
+        }).candidates;
+        const picks = candidates
+          .filter((candidate) => !pickedUrls || pickedUrls.includes(candidate.url))
+          .map((candidate) => ({ url: candidate.url, mainTheme: 'Carbon Markets', reason: 'ok' }));
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ content: [{ type: 'text', text: JSON.stringify({ picks }) }] }),
+        };
       }
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
-          data: {
-            markdown: entry.markdown,
-            metadata: {
-              'article:published_time': entry.publishedTime ?? daysAgoIso(2),
-              author: entry.author ?? '',
-            },
-          },
-        }),
-      };
+      throw new Error(`Unexpected fetch URL ${url}`);
     }),
   );
 }
@@ -72,233 +74,60 @@ describe('scrapeEsgNews', () => {
     vi.clearAllMocks();
   });
 
-  it('hits the publisher search URL for discovery (recency comes from there)', async () => {
-    const theme = stubTheme({ esgNewsSearchTerms: 'methane policy' });
-    const fetchSpy = vi.fn(async (_url: string, _init: { body: string }) => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ data: { markdown: '', metadata: {} } }),
-    }));
-    vi.stubGlobal('fetch', fetchSpy);
-
-    await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    const requested = (JSON.parse(fetchSpy.mock.calls[0]![1].body) as { url: string }).url;
-    expect(requested).toBe('https://esgnews.com/?s=methane%20policy');
+  it('fetches the publisher RSS feed for discovery', async () => {
+    installFetch(feedXml([{ title: 'A', link: 'https://esgnews.com/a/' }]));
+    await scrapeEsgNews(new Set(), [], KEY);
+    expect(vi.mocked(fetch).mock.calls[0]![0]).toBe(FEED_URL);
   });
 
-  it('returns a sanitized RawArticle and strips page chrome from markdown', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([{ url: 'https://esgnews.com/nz/', title: 'NZ Climate Law' }]),
-      },
-      'https://esgnews.com/nz/': {
-        markdown:
-          'Climate\n/\nGovernment\n/\nNews\nby ESG News Editorial Team\n' +
-          'Share:\nShare on Facebook\nShare on LinkedIn\n' +
-          'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.\n' +
-          'RELATED ARTICLE: New Zealand Lifts Climate Reporting Thresholds\n' +
-          'Subscribe & Follow for Daily ESG Insights\n' +
-          'ESG News Editorial Team The ESG News Editorial Team is comprised of veteran journalists.',
-        author: 'ESG News Editorial Team',
-        publishedTime: daysAgoIso(3),
-      },
-    });
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
+  it('returns curated RawArticles tagged with the curator-assigned theme', async () => {
+    installFetch(feedXml([{ title: 'Methane Rule Tightens', link: 'https://esgnews.com/methane-rule/' }]));
+    const result = await scrapeEsgNews(new Set(), [], KEY);
     expect(result).toHaveLength(1);
     const article = result[0]!;
     expect(article.source).toBe('esgnews');
-    expect(article.url).toBe('https://esgnews.com/nz/');
-    expect(article.author).toBe('ESG News Editorial Team');
-    expect(article.fullContent).toContain(
-      'New Zealand plans to amend the Climate Change Response Act 2002 to block claims.',
-    );
-    expect(article.fullContent).not.toMatch(/Share on (Facebook|LinkedIn)/);
-    expect(article.fullContent).not.toMatch(/RELATED ARTICLE:/);
-    expect(article.fullContent).not.toMatch(/Subscribe & Follow/);
-    expect(article.fullContent).not.toMatch(/Editorial Team is comprised of/);
+    expect(article.url).toBe('https://esgnews.com/methane-rule/');
+    expect(article.title).toBe('Methane Rule Tightens');
+    expect(article.mainTheme).toBe('Carbon Markets');
+    expect(article.author).toBe('ESG News');
+    expect(article.fullContent).toContain('climate policy and methane');
   });
 
-  it('filters tag/category/author/page/region/wp-*/static-page index links out of the listing', async () => {
-    const theme = stubTheme();
-    const scrapedUrls: string[] = [];
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { url?: string };
-        if (body.url === listingUrl(theme)) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: {
-                markdown: listingMarkdown([
-                  { url: 'https://esgnews.com/tag/methane/', title: 'Methane tag' },
-                  { url: 'https://esgnews.com/category/policy/', title: 'Policy category' },
-                  { url: 'https://esgnews.com/author/someone/', title: 'Author page' },
-                  { url: 'https://esgnews.com/page/12/', title: 'Page 12' },
-                  { url: 'https://esgnews.com/esg-europe/page/15/', title: 'EU index' },
-                  { url: 'https://esgnews.com/esg-americas/page/3/', title: 'Americas index' },
-                  { url: 'https://esgnews.com/feed/', title: 'RSS feed' },
-                  { url: 'https://esgnews.com/wp-admin/edit.php', title: 'WP admin' },
-                  { url: 'https://esgnews.com/wp-content/uploads/2026/x.jpg', title: 'Upload' },
-                  { url: 'https://esgnews.com/wp-json/wp/v2/posts', title: 'WP JSON API' },
-                  { url: 'https://esgnews.com/about/', title: 'About' },
-                  { url: 'https://esgnews.com/contact/', title: 'Contact' },
-                  { url: 'https://esgnews.com/real-article-slug/', title: 'Real Article' },
-                ]),
-                metadata: {},
-              },
-            }),
-          };
-        }
-        scrapedUrls.push(body.url ?? '');
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: 'A real article body about carbon market policy and methane regulation.',
-              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
-            },
-          }),
-        };
-      }),
+  it('returns only the articles the curator picked', async () => {
+    installFetch(
+      feedXml([
+        { title: 'Picked', link: 'https://esgnews.com/picked/' },
+        { title: 'Dropped', link: 'https://esgnews.com/dropped/' },
+      ]),
+      ['https://esgnews.com/picked/'],
     );
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    // Only the real article should have been scraped; no index/static page hit Firecrawl.
-    expect(scrapedUrls).toEqual(['https://esgnews.com/real-article-slug/']);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.url).toBe('https://esgnews.com/real-article-slug/');
+    const result = await scrapeEsgNews(new Set(), [], KEY);
+    expect(result.map((article) => article.url)).toEqual(['https://esgnews.com/picked/']);
   });
 
-  it('filters index paths regardless of trailing slash (no-trailing-slash variants too)', async () => {
-    // Cursor bot finding on PR #36: prefix-list with trailing `/` would let
-    // `https://esgnews.com/about` (no slash) through. First-segment matching
-    // catches both `/about` and `/about/`.
-    const theme = stubTheme();
-    const scrapedUrls: string[] = [];
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { url?: string };
-        if (body.url === listingUrl(theme)) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: {
-                markdown: listingMarkdown([
-                  { url: 'https://esgnews.com/about', title: 'About no-slash' },
-                  { url: 'https://esgnews.com/tag', title: 'Tag root no-slash' },
-                  { url: 'https://esgnews.com/wp-admin', title: 'WP admin no-slash' },
-                  { url: 'https://esgnews.com/feedback-policy/', title: 'Real Article (feedback)' },
-                ]),
-                metadata: {},
-              },
-            }),
-          };
-        }
-        scrapedUrls.push(body.url ?? '');
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: 'A feedback-policy article body — should be scraped, not excluded by /feed.',
-              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
-            },
-          }),
-        };
-      }),
-    );
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    // /about, /tag, /wp-admin all rejected (slug-less or known index first-segment).
-    // /feedback-policy/ accepted (first segment is "feedback-policy", not "feed").
-    expect(scrapedUrls).toEqual(['https://esgnews.com/feedback-policy/']);
-    expect(result).toHaveLength(1);
-  });
-
-  it('rejects multi-segment paths the prefix list doesn\'t enumerate (depth-1 safety net)', async () => {
-    const theme = stubTheme();
-    const scrapedUrls: string[] = [];
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { url?: string };
-        if (body.url === listingUrl(theme)) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: {
-                markdown: listingMarkdown([
-                  // Hypothetical new index types (e.g. CMS migration adds these
-                  // overnight); the prefix list wouldn't enumerate them yet,
-                  // but the depth-1 segment check rejects them anyway.
-                  { url: 'https://esgnews.com/topic/methane/', title: 'New topic index' },
-                  { url: 'https://esgnews.com/region/europe/digest/', title: 'Deep listing' },
-                  { url: 'https://esgnews.com/finalists-2026-emissions-rule/', title: 'Real Article' },
-                ]),
-                metadata: {},
-              },
-            }),
-          };
-        }
-        scrapedUrls.push(body.url ?? '');
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: 'A real article body about a finalised emissions rule.',
-              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
-            },
-          }),
-        };
-      }),
-    );
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    expect(scrapedUrls).toEqual(['https://esgnews.com/finalists-2026-emissions-rule/']);
-    expect(result).toHaveLength(1);
-  });
-
-  it('skips results already in processedUrls (no article scrape call)', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([{ url: 'https://esgnews.com/seen/', title: 'Seen Article' }]),
-      },
-    });
-    const result = await scrapeEsgNews(
-      [theme],
-      new Set(['https://esgnews.com/seen/']),
-      [],
-      KEY,
-    );
+  it('skips feed items already in processedUrls', async () => {
+    installFetch(feedXml([{ title: 'Seen', link: 'https://esgnews.com/seen/' }]));
+    const result = await scrapeEsgNews(new Set(['https://esgnews.com/seen/']), [], KEY);
     expect(result).toHaveLength(0);
   });
 
-  it('skips results that duplicate a Carbon Pulse title', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([
-          { url: 'https://esgnews.com/dup/', title: 'Global Methane Pledge Reaches Milestone' },
-        ]),
-      },
-    });
+  it('skips feed items older than the age limit', async () => {
+    installFetch(feedXml([{ title: 'Old', link: 'https://esgnews.com/old/', daysAgo: 120 }]));
+    const result = await scrapeEsgNews(new Set(), [], KEY);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips feed items with no parseable pubDate', async () => {
+    installFetch(feedXml([{ title: 'Undated', link: 'https://esgnews.com/undated/', pubDate: 'not-a-date' }]));
+    const result = await scrapeEsgNews(new Set(), [], KEY);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips feed items that duplicate a Carbon Pulse title', async () => {
+    installFetch(
+      feedXml([{ title: 'Global Methane Pledge Reaches Milestone', link: 'https://esgnews.com/dup/' }]),
+    );
     const result = await scrapeEsgNews(
-      [theme],
       new Set(),
       ['Global Methane Pledge Reaches Major Milestone Today'],
       KEY,
@@ -306,328 +135,71 @@ describe('scrapeEsgNews', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('skips articles older than the age limit', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([{ url: 'https://esgnews.com/old/', title: 'Old Article' }]),
-      },
-      'https://esgnews.com/old/': {
-        markdown: 'This is a sufficiently long article body about carbon markets.',
-        publishedTime: daysAgoIso(120),
-      },
-    });
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-    expect(result).toHaveLength(0);
-  });
-
-  it('skips pages that sanitize to empty (chrome-only)', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([{ url: 'https://esgnews.com/chrome/', title: 'Chrome Only' }]),
-      },
-      'https://esgnews.com/chrome/': {
-        markdown: 'Share:\nShare on Facebook\nSubscribe & Follow\nRELATED ARTICLE: Something',
-        publishedTime: daysAgoIso(1),
-      },
-    });
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-    expect(result).toHaveLength(0);
-  });
-
-  it('continues other themes when one theme discovery fails', async () => {
-    const badTheme = stubTheme({ name: 'Bad', esgNewsSearchTerms: 'boom' });
-    const goodTheme = stubTheme({ name: 'Good' });
-    installFetch({
-      [listingUrl(badTheme)]: { status: 500 },
-      [listingUrl(goodTheme)]: {
-        markdown: listingMarkdown([{ url: 'https://esgnews.com/ok/', title: 'Good One' }]),
-      },
-      'https://esgnews.com/ok/': {
-        markdown: 'A solid article body about composting infrastructure and policy.',
-        publishedTime: daysAgoIso(2),
-        author: 'ESG News',
-      },
-    });
-
-    const result = await scrapeEsgNews([badTheme, goodTheme], new Set(), [], KEY);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]!.mainTheme).toBe('Good');
-  });
-
-  it('skips a single article whose scrape fails but keeps the others', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([
-          { url: 'https://esgnews.com/bad/', title: 'Bad Scrape' },
-          { url: 'https://esgnews.com/good/', title: 'Good Scrape' },
-        ]),
-      },
-      'https://esgnews.com/bad/': { status: 500 },
-      'https://esgnews.com/good/': {
-        markdown: 'A complete article body discussing carbon market regulation in depth.',
-        publishedTime: daysAgoIso(1),
-      },
-    });
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]!.url).toBe('https://esgnews.com/good/');
-  });
-
-  it('skips an article with no parseable publish date (parity with carbon-pulse)', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([{ url: 'https://esgnews.com/undated/', title: 'Undated' }]),
-      },
-      'https://esgnews.com/undated/': {
-        markdown: 'A perfectly valid long article body with no date metadata.',
-        publishedTime: '',
-      },
-    });
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-    expect(result).toHaveLength(0);
-  });
-
-  it('scrapes at most MAX_ARTICLES_PER_THEME eligible results', async () => {
-    const theme = stubTheme();
-    let articleScrapes = 0;
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { url?: string };
-        if (body.url === listingUrl(theme)) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: {
-                markdown: listingMarkdown([
-                  { url: 'https://esgnews.com/1/', title: 'One' },
-                  { url: 'https://esgnews.com/2/', title: 'Two' },
-                  { url: 'https://esgnews.com/3/', title: 'Three' },
-                ]),
-                metadata: {},
-              },
-            }),
-          };
-        }
-        articleScrapes += 1;
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: `Body for ${body.url} with enough prose to survive sanitization.`,
-              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
-            },
-          }),
-        };
-      }),
+  it('skips feed items whose body sanitizes to empty (chrome-only)', async () => {
+    installFetch(
+      feedXml([
+        {
+          title: 'Chrome Only',
+          link: 'https://esgnews.com/chrome/',
+          content: '<p>Share on Facebook</p><p>RELATED ARTICLE: Something</p><p>Subscribe &amp; Follow</p>',
+        },
+      ]),
     );
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    expect(articleScrapes).toBe(2);
-    expect(result).toHaveLength(2);
+    const result = await scrapeEsgNews(new Set(), [], KEY);
+    expect(result).toHaveLength(0);
   });
 
-  it('aborts the remaining themes when the listing scrape itself returns 402 (quota)', async () => {
-    const quotaTheme = stubTheme({ name: 'First', esgNewsSearchTerms: 'first' });
-    const wouldBeNextTheme = stubTheme({ name: 'Second', esgNewsSearchTerms: 'second' });
-    const requestedUrls: string[] = [];
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { url?: string };
-        requestedUrls.push(body.url ?? '');
-        if (body.url === listingUrl(quotaTheme)) {
-          return { ok: false, status: 402, json: async () => ({}) };
-        }
-        return { ok: true, status: 200, json: async () => ({ data: { markdown: '', metadata: {} } }) };
-      }),
+  it('strips page chrome from the article body but keeps the prose', async () => {
+    installFetch(
+      feedXml([
+        {
+          title: 'Real Article',
+          link: 'https://esgnews.com/real/',
+          content:
+            '<p>New Zealand plans to amend the Climate Change Response Act 2002.</p>' +
+            '<p>Share on LinkedIn</p><p>RELATED ARTICLE: Something Else</p>',
+        },
+      ]),
     );
+    const result = await scrapeEsgNews(new Set(), [], KEY);
+    expect(result).toHaveLength(1);
+    const body = result[0]!.fullContent;
+    expect(body).toContain('New Zealand plans to amend the Climate Change Response Act 2002.');
+    expect(body).not.toMatch(/Share on LinkedIn/);
+    expect(body).not.toMatch(/RELATED ARTICLE:/);
+  });
 
-    const result = await scrapeEsgNews([quotaTheme, wouldBeNextTheme], new Set(), [], KEY);
-
+  it('returns an empty list and does not call the curator when no candidates are fresh', async () => {
+    installFetch(feedXml([{ title: 'Old', link: 'https://esgnews.com/old/', daysAgo: 120 }]));
+    const result = await scrapeEsgNews(new Set(), [], KEY);
     expect(result).toEqual([]);
-    // The second theme's listing must NOT be requested — the loop short-circuited.
-    expect(requestedUrls).not.toContain(listingUrl(wouldBeNextTheme));
+    const anthropicCalls = vi.mocked(fetch).mock.calls.filter(([url]) => url === ANTHROPIC_URL);
+    expect(anthropicCalls).toHaveLength(0);
   });
 
-  it.each([402, 429] as const)(
-    'aborts the theme on a Firecrawl %s quota/rate-limit response from per-article scrapes',
-    async (status) => {
-      const quotaTheme = stubTheme({ name: 'Quota', esgNewsSearchTerms: 'quota' });
-      const fineTheme = stubTheme({ name: 'Fine' });
-      installFetch({
-        [listingUrl(quotaTheme)]: {
-          markdown: listingMarkdown([
-            { url: 'https://esgnews.com/q1/', title: 'Q1' },
-            { url: 'https://esgnews.com/q2/', title: 'Q2' },
-          ]),
-        },
-        [listingUrl(fineTheme)]: {
-          markdown: listingMarkdown([{ url: 'https://esgnews.com/ok/', title: 'OK' }]),
-        },
-        'https://esgnews.com/q1/': { status },
-        'https://esgnews.com/q2/': { status },
-        'https://esgnews.com/ok/': {
-          markdown: 'A healthy article body about carbon market regulation.',
-          publishedTime: daysAgoIso(1),
-        },
-      });
-
-      const result = await scrapeEsgNews([quotaTheme, fineTheme], new Set(), [], KEY);
-
-      expect(result).toHaveLength(1);
-      expect(result[0]!.mainTheme).toBe('Fine');
-    },
-  );
-
-  it('fills the per-theme cap from later candidates when early ones are skipped', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([
-          { url: 'https://esgnews.com/undated/', title: 'Undated' },
-          { url: 'https://esgnews.com/stale/', title: 'Stale' },
-          { url: 'https://esgnews.com/good1/', title: 'Good 1' },
-          { url: 'https://esgnews.com/good2/', title: 'Good 2' },
-        ]),
-      },
-      'https://esgnews.com/undated/': { markdown: 'Valid body but no date.', publishedTime: '' },
-      'https://esgnews.com/stale/': {
-        markdown: 'Valid body but ancient.',
-        publishedTime: daysAgoIso(120),
-      },
-      'https://esgnews.com/good1/': {
-        markdown: 'Fresh article one about carbon markets and policy.',
-        publishedTime: daysAgoIso(1),
-      },
-      'https://esgnews.com/good2/': {
-        markdown: 'Fresh article two about composting infrastructure.',
-        publishedTime: daysAgoIso(2),
-      },
-    });
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    expect(result.map((article) => article.url)).toEqual([
-      'https://esgnews.com/good1/',
-      'https://esgnews.com/good2/',
-    ]);
-  });
-
-  it('stops scraping per-theme candidates after the hard cap (5) to bound credit spend', async () => {
-    const theme = stubTheme();
-    const links = Array.from({ length: 8 }, (_unused, index) => ({
-      url: `https://esgnews.com/c${index}/`,
-      title: `Candidate ${index}`,
+  it('caps the candidate pool sent to the curator at 30', async () => {
+    const items = Array.from({ length: 40 }, (_unused, index) => ({
+      title: `Article ${index}`,
+      link: `https://esgnews.com/a${index}/`,
     }));
-    const articleScrapes: Record<string, { markdown: string; publishedTime: string }> = {};
-    for (const link of links) {
-      articleScrapes[link.url] = { markdown: '', publishedTime: '' };
-    }
-    const fetchSpy = vi.fn(async (_url: string, init: { body: string }) => {
-      const body = JSON.parse(init.body) as { url: string };
-      if (body.url === listingUrl(theme)) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ data: { markdown: listingMarkdown(links), metadata: {} } }),
-        };
-      }
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
-          data: { markdown: '', metadata: { 'article:published_time': '' } },
-        }),
-      };
-    });
-    vi.stubGlobal('fetch', fetchSpy);
-
-    await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    // 1 listing scrape + at most 5 candidate scrapes
-    expect(fetchSpy).toHaveBeenCalledTimes(6);
+    installFetch(feedXml(items), []);
+    await scrapeEsgNews(new Set(), [], KEY);
+    const anthropicCall = vi.mocked(fetch).mock.calls.find(([url]) => url === ANTHROPIC_URL)!;
+    const body = JSON.parse((anthropicCall[1] as { body: string }).body) as {
+      messages: Array<{ content: string }>;
+    };
+    const userPrompt = body.messages[0]!.content;
+    const candidates = (JSON.parse(userPrompt.slice(0, userPrompt.indexOf('\n\n'))) as {
+      candidates: unknown[];
+    }).candidates;
+    expect(candidates).toHaveLength(30);
   });
 
-  it('preserves articles already collected when a later scrape hits a quota error', async () => {
-    const theme = stubTheme();
-    installFetch({
-      [listingUrl(theme)]: {
-        markdown: listingMarkdown([
-          { url: 'https://esgnews.com/collected/', title: 'Collected' },
-          { url: 'https://esgnews.com/quota/', title: 'Quota' },
-        ]),
-      },
-      'https://esgnews.com/collected/': {
-        markdown: 'A solid article body about methane monitoring.',
-        publishedTime: daysAgoIso(1),
-      },
-      'https://esgnews.com/quota/': { status: 402 },
-    });
-
-    const result = await scrapeEsgNews([theme], new Set(), [], KEY);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]!.url).toBe('https://esgnews.com/collected/');
-  });
-
-  it('does not re-scrape an article that already matched an earlier theme', async () => {
-    const themeA = stubTheme({ name: 'Theme A', esgNewsSearchTerms: 'aaa' });
-    const themeB = stubTheme({ name: 'Theme B', esgNewsSearchTerms: 'bbb' });
-    let articleScrapes = 0;
+  it('rejects when the feed fetch returns a non-2xx status', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (_url: string, init: { body: string }) => {
-        const body = JSON.parse(init.body) as { url?: string };
-        if (body.url === listingUrl(themeA) || body.url === listingUrl(themeB)) {
-          // Every theme listing surfaces the SAME article.
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: {
-                markdown: listingMarkdown([
-                  { url: 'https://esgnews.com/shared/', title: 'Shared' },
-                ]),
-                metadata: {},
-              },
-            }),
-          };
-        }
-        articleScrapes += 1;
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            data: {
-              markdown: 'An ESG article matching multiple themes about methane policy.',
-              metadata: { 'article:published_time': daysAgoIso(1), author: 'ESG News' },
-            },
-          }),
-        };
-      }),
+      vi.fn(async () => ({ ok: false, status: 503, text: async () => '' })),
     );
-
-    const result = await scrapeEsgNews([themeA, themeB], new Set(), [], KEY);
-
-    expect(articleScrapes).toBe(1);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.url).toBe('https://esgnews.com/shared/');
-  });
-
-  it('throws when the Firecrawl API key is not configured', async () => {
-    await expect(scrapeEsgNews([stubTheme()], new Set(), [], '')).rejects.toThrow(
-      /FIRECRAWL_API_KEY not configured/,
-    );
+    await expect(scrapeEsgNews(new Set(), [], KEY)).rejects.toThrow(/HTTP 503/);
   });
 });

--- a/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
+++ b/apps/news-digest/pipeline/src/scraper/__tests__/trellis.spec.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { ThemeConfig } from '../../types.js';
 
-vi.mock('../../ai/trellis-curator.js', () => ({
-  curateTrellisArticles: vi.fn(),
+vi.mock('../../ai/article-curator.js', () => ({
+  curateArticles: vi.fn(),
 }));
 
-import { curateTrellisArticles } from '../../ai/trellis-curator.js';
+import { curateArticles } from '../../ai/article-curator.js';
 import { THEMES } from '../../config.constants.js';
 import { scrapeTrellis } from '../trellis.js';
 
@@ -81,7 +81,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('extracts a sanitized RawArticle per theme and strips chrome', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -109,7 +109,7 @@ describe('scrapeTrellis', () => {
 
   it('hits the publisher search URL for per-theme discovery', async () => {
     const theme = stubTheme({ trellisSearchTerms: 'methane policy' });
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const seen = new Set<string>();
     vi.stubGlobal(
       'fetch',
@@ -131,7 +131,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('skips URLs already in processedUrls (no scrape)', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -149,7 +149,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('skips undated and too-old articles', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -170,7 +170,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('skips a page that sanitizes to empty (chrome-only)', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -187,7 +187,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('continues other themes when one theme discovery fails', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const badTheme = stubTheme({ name: 'Bad', trellisSearchTerms: 'boom' });
     const goodTheme = stubTheme({ name: 'Good' });
     installFetch({
@@ -224,7 +224,7 @@ describe('scrapeTrellis', () => {
         publishedTime: daysAgoIso(1),
       },
     });
-    vi.mocked(curateTrellisArticles).mockResolvedValue([
+    vi.mocked(curateArticles).mockResolvedValue([
       { url: 'https://trellis.net/article/c1/', mainTheme: 'Methane & Super Pollutants' },
     ]);
 
@@ -234,7 +234,7 @@ describe('scrapeTrellis', () => {
     expect(result[0]!.url).toBe('https://trellis.net/article/c1/');
     expect(result[0]!.mainTheme).toBe('Methane & Super Pollutants');
 
-    const [candidates, themeNames] = vi.mocked(curateTrellisArticles).mock.calls[0]!;
+    const [candidates, themeNames] = vi.mocked(curateArticles).mock.calls[0]!;
     expect(candidates[0]).toMatchObject({
       url: 'https://trellis.net/article/c1/',
       title: 'Cand 1',
@@ -262,11 +262,11 @@ describe('scrapeTrellis', () => {
     const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(1);
-    expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
+    expect(vi.mocked(curateArticles)).not.toHaveBeenCalled();
   });
 
   it('returns only per-theme articles when the curation discovery fails (resilience)', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -284,11 +284,11 @@ describe('scrapeTrellis', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]!.url).toBe('https://trellis.net/article/pt/');
-    expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
+    expect(vi.mocked(curateArticles)).not.toHaveBeenCalled();
   });
 
   it('fills the per-theme cap from later candidates when early ones are skipped (cap on successful extractions)', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -316,7 +316,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('stops scraping per-theme candidates after the hard cap (5) to bound credit spend', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     const links = Array.from({ length: 8 }, (_unused, index) => ({
       url: `https://trellis.net/article/c${index}/`,
@@ -356,7 +356,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('returns only per-theme articles when the curator itself throws (Anthropic outage)', async () => {
-    vi.mocked(curateTrellisArticles).mockRejectedValue(new Error('anthropic 401'));
+    vi.mocked(curateArticles).mockRejectedValue(new Error('anthropic 401'));
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -395,7 +395,7 @@ describe('scrapeTrellis', () => {
       },
       'https://trellis.net/article/quota/': { status: 402 },
     });
-    vi.mocked(curateTrellisArticles).mockResolvedValue([
+    vi.mocked(curateArticles).mockResolvedValue([
       { url: 'https://trellis.net/article/good/', mainTheme: 'Carbon Markets' },
       { url: 'https://trellis.net/article/quota/', mainTheme: 'Carbon Markets' },
     ]);
@@ -429,7 +429,7 @@ describe('scrapeTrellis', () => {
       const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
       expect(result).toHaveLength(0);
-      expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
+      expect(vi.mocked(curateArticles)).not.toHaveBeenCalled();
     },
   );
 
@@ -449,11 +449,11 @@ describe('scrapeTrellis', () => {
     const result = await scrapeTrellis([theme], new Set(), ANTHROPIC, KEY);
 
     expect(result).toHaveLength(0);
-    expect(vi.mocked(curateTrellisArticles)).not.toHaveBeenCalled();
+    expect(vi.mocked(curateArticles)).not.toHaveBeenCalled();
   });
 
   it('rejects off-domain and non-article URLs from listings', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const theme = stubTheme();
     installFetch({
       [themeListingUrl(theme)]: {
@@ -488,7 +488,7 @@ describe('scrapeTrellis', () => {
         publishedTime: daysAgoIso(1),
       },
     });
-    vi.mocked(curateTrellisArticles).mockResolvedValue([
+    vi.mocked(curateArticles).mockResolvedValue([
       { url: 'https://trellis.net/article/dup/', mainTheme: 'Carbon Markets' },
       { url: 'https://trellis.net/article/dup/', mainTheme: 'Carbon Markets' },
     ]);
@@ -500,7 +500,7 @@ describe('scrapeTrellis', () => {
   });
 
   it('does not re-scrape an article that already matched an earlier theme', async () => {
-    vi.mocked(curateTrellisArticles).mockResolvedValue([]);
+    vi.mocked(curateArticles).mockResolvedValue([]);
     const themeA = stubTheme({ name: 'Theme A', trellisSearchTerms: 'aaa' });
     const themeB = stubTheme({ name: 'Theme B', trellisSearchTerms: 'bbb' });
     let scrapeCalls = 0;

--- a/apps/news-digest/pipeline/src/scraper/esg-news.ts
+++ b/apps/news-digest/pipeline/src/scraper/esg-news.ts
@@ -1,75 +1,50 @@
-import { sanitizeArticleText } from '../helpers/content.helpers.js';
-import { parseDate } from '../helpers/date.helpers.js';
-import {
-  FirecrawlError,
-  extractMarkdownLinks,
-  firecrawlScrape,
-} from '../helpers/firecrawl.helpers.js';
-import type { RawArticle, ThemeConfig } from '../types.js';
-
-const MAX_ARTICLES_PER_THEME = 2;
-// Hard cap on per-theme candidate scrapes — without it, a listing with N
-// links iterates until 2 succeed or the list is exhausted, and most
-// candidates fail the publish-date / freshness / sanitization barrier
-// (1 credit each). The listing is date-desc, so anything past #5 is
-// already drifting toward the 30-day freshness cliff anyway.
-const MAX_CANDIDATES_PER_THEME = 5;
-const MAX_ARTICLE_AGE_DAYS = 30;
-const LISTING_URL_BASE = 'https://esgnews.com/?s=';
-
-// ESG News article permalinks are slug-only at the root (`/some-slug/`).
-// These first-path-segments mark tag/category/author/pagination/region/
-// static-page routes that the search page also links to — exclude them so
-// we don't waste credits scraping a non-article page (the old `/search`
-// flow burnt 16 scrapes on these in the 2026-05-19 validation run).
+// ESG News discovery — RSS feed.
 //
-// Matching on the FIRST segment (not a prefix string) handles trailing-slash
-// variants uniformly: `/about`, `/about/`, and `/about/us/` all canonicalize
-// to first-segment `'about'`. The earlier prefix-list approach required
-// every entry to end with `/`, and a single missing slash silently let the
-// no-trailing-slash form through (cursor-bot finding on PR #36).
-const ESG_INDEX_FIRST_SEGMENTS: ReadonlySet<string> = new Set([
-  'tag',
-  'category',
-  'author',
-  'page',
-  'esg-europe',
-  'esg-americas',
-  'esg-africa',
-  'esg-asia-pacific',
-  'feed',
-  'wp-admin',
-  'wp-content',
-  'wp-json',
-  'about',
-  'contact',
-  'subscribe',
-  'authors',
-]);
+// ESG News has no usable server-side search: `esgnews.com/?s=<term>` ignores
+// the query term *and* `orderby` entirely and returns the same fixed post grid
+// for every request (validated 2026-05-21 — the old `?s=` discovery surfaced
+// ~0 fresh articles and collapsed the digest to a single article). The
+// publisher's WordPress RSS feed, by contrast, is clean: date-desc ordered,
+// real `<pubDate>`, and `<content:encoded>` carries the full article body —
+// so ESG needs no Firecrawl at all (same model as the Substack scraper).
+//
+// Discovery is global (one feed fetch, no per-theme loop); the shared article
+// curator picks the most digest-worthy items and assigns each a theme.
 
-function isEsgNewsArticleUrl(url: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return false;
-  }
-  const host = parsed.hostname.toLowerCase();
-  if (host !== 'esgnews.com' && !host.endsWith('.esgnews.com')) return false;
-  const segments = parsed.pathname.toLowerCase().split('/').filter((segment) => segment.length > 0);
-  if (segments.length === 0) return false;
-  if (ESG_INDEX_FIRST_SEGMENTS.has(segments[0]!)) return false;
-  // Article permalinks are exactly one segment under root (`/slug/`).
-  // Multi-segment paths (`/topic/methane/`, future index types) are
-  // rejected so we don't need to keep extending the exclusion set
-  // ahead of every CMS change.
-  return segments.length === 1;
+import { XMLParser } from 'fast-xml-parser';
+import { THEMES } from '../config.constants.js';
+import { curateArticles, type ArticleCandidate } from '../ai/article-curator.js';
+import { sanitizeArticleText } from '../helpers/content.helpers.js';
+import { stripHtml } from './substack.js';
+import type { RawArticle } from '../types.js';
+
+const ESG_NEWS_FEED_URL = 'https://esgnews.com/feed/';
+const FETCH_TIMEOUT_MS = 15_000;
+const MAX_ARTICLE_AGE_DAYS = 30;
+// Cap on candidates handed to the curator. The feed carries ~50 recent items;
+// after the freshness + dedup filters this is rarely hit, but it bounds the
+// curator prompt size if the feed ever balloons.
+const MAX_CANDIDATES = 30;
+// ESG News is the digest's primary source while Carbon Pulse is disabled, so
+// it gets a higher pick budget than Trellis (which keeps the curator default).
+const MAX_PICKS = 3;
+
+interface RssItem {
+  readonly title?: string;
+  readonly link?: string;
+  readonly pubDate?: string;
+  readonly description?: string;
+  readonly 'content:encoded'?: string;
+  readonly 'dc:creator'?: string;
 }
 
-function isQuotaError(error: unknown): boolean {
-  return (
-    error instanceof FirecrawlError && (error.status === 402 || error.status === 429)
-  );
+interface FeedArticle {
+  readonly url: string;
+  readonly title: string;
+  readonly date: string;
+  readonly author: string;
+  readonly excerpt: string;
+  readonly fullContent: string;
 }
 
 function isDuplicateOfCarbonPulse(title: string, cpTitles: readonly string[]): boolean {
@@ -84,128 +59,128 @@ function isDuplicateOfCarbonPulse(title: string, cpTitles: readonly string[]): b
   });
 }
 
-async function discoverAndScrape(
-  theme: ThemeConfig,
+/** Normalize the feed XML into RSS `<item>` records. */
+function parseFeedItems(xml: string): readonly RssItem[] {
+  const parser = new XMLParser({ ignoreAttributes: true });
+  const parsed = parser.parse(xml) as { rss?: { channel?: { item?: RssItem | RssItem[] } } };
+  if (typeof parsed !== 'object' || parsed === null || typeof parsed.rss !== 'object' || parsed.rss === null) {
+    throw new Error('Invalid RSS: not an object');
+  }
+  const channel = parsed.rss.channel;
+  if (!channel || typeof channel !== 'object') {
+    throw new Error('Invalid RSS: missing channel');
+  }
+  const itemsRaw = channel.item;
+  return Array.isArray(itemsRaw) ? itemsRaw : itemsRaw ? [itemsRaw] : [];
+}
+
+/**
+ * Fetch the ESG News RSS feed and turn it into freshness-filtered, deduped
+ * article candidates — the per-article body comes straight from
+ * `content:encoded` (no second network call), then through the shared
+ * sanitizer barrier.
+ */
+async function fetchFeedArticles(
   processedUrls: ReadonlySet<string>,
   cpTitles: readonly string[],
-  apiKey: string,
-): Promise<RawArticle[]> {
-  // Hit ESG News's own WordPress search (default order: publish-date-desc)
-  // and read links straight from the markdown. This is what gives us
-  // recency — Firecrawl's `/v2/search` upstream index lacks dates on this
-  // publisher and binary-filtered every result when `tbs` was applied
-  // (PR #34 → reverted in #35; see firecrawl.helpers note).
-  const listingUrl = `${LISTING_URL_BASE}${encodeURIComponent(theme.esgNewsSearchTerms)}`;
-  const listing = await firecrawlScrape(listingUrl, apiKey);
-
-  const candidates = extractMarkdownLinks(listing.markdown, ({ url, title }) => {
-    if (!isEsgNewsArticleUrl(url)) return false;
-    if (processedUrls.has(url)) return false;
-    if (isDuplicateOfCarbonPulse(title, cpTitles)) return false;
-    return true;
+): Promise<FeedArticle[]> {
+  const response = await fetch(ESG_NEWS_FEED_URL, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${ESG_NEWS_FEED_URL}`);
+  }
+  const items = parseFeedItems(await response.text());
+  const cutoffMs = Date.now() - MAX_ARTICLE_AGE_DAYS * 24 * 60 * 60 * 1000;
 
-  // Cap on *successful* extractions (MAX_ARTICLES_PER_THEME) plus a hard
-  // ceiling on attempts (MAX_CANDIDATES_PER_THEME) so a low-yield listing
-  // can't burn the whole link list one credit at a time. The listing is
-  // date-desc so the freshest candidates are scanned first.
-  const articles: RawArticle[] = [];
-  for (const candidate of candidates.slice(0, MAX_CANDIDATES_PER_THEME)) {
-    if (articles.length >= MAX_ARTICLES_PER_THEME) break;
-    try {
-      const scraped = await firecrawlScrape(candidate.url, apiKey);
-      // No reliable publish date — skip rather than stamp it "today" and let a
-      // stale article bypass the freshness window (parity with carbon-pulse.ts).
-      // Split the two failure modes so a Firecrawl metadata-schema regression
-      // (parseable string suddenly returning unparseable) is visibly distinct
-      // from publisher pages that genuinely lack a date.
-      if (!scraped.publishedTime) {
-        console.warn(`[ESG News] No publish_time metadata, skipping: ${candidate.url}`);
-        continue;
-      }
-      const articleDate = parseDate(scraped.publishedTime);
-      if (!articleDate) {
-        console.error(
-          `[ESG News] Unparseable publish_time "${scraped.publishedTime}", skipping: ${candidate.url}`,
-        );
-        continue;
-      }
-      const ageMs = Date.now() - new Date(articleDate).getTime();
-      if (ageMs > MAX_ARTICLE_AGE_DAYS * 24 * 60 * 60 * 1000) {
-        console.warn(`[ESG News] Article too old (${articleDate}), skipping: ${candidate.url}`);
-        continue;
-      }
-      // Firecrawl markdown still carries breadcrumbs, share buttons, newsletter
-      // signup and the editorial-team bio (spike Robustness #7). Strip it at the
-      // source — the same defense-in-depth barrier used for every scraper.
-      const cleanContent = sanitizeArticleText(scraped.markdown);
-      if (!cleanContent) {
-        console.warn(`[ESG News] No article body after sanitization, skipping: ${candidate.url}`);
-        continue;
-      }
-      articles.push({
-        source: 'esgnews',
-        url: candidate.url,
-        title: candidate.title,
-        date: articleDate,
-        author: scraped.author || 'ESG News',
-        mainTheme: theme.name,
-        categories: '',
-        location: '',
-        fullContent: cleanContent,
-      });
-    } catch (error: unknown) {
-      // Quota (402) / rate-limit (429): every remaining candidate would hit the
-      // same wall. Stop scraping this theme but KEEP what was already collected
-      // — throwing here would discard the partial `articles` for this theme.
-      if (isQuotaError(error)) {
-        const status = (error as FirecrawlError).status;
-        console.error(
-          `[ESG News] Firecrawl ${status} (quota/rate limit) — aborting theme, keeping ${articles.length} collected`,
-        );
-        break;
-      }
-      const message = error instanceof Error ? error.message : 'unknown';
-      console.error(`Failed to extract ESG News article "${candidate.title}": ${message}`);
+  const articles: FeedArticle[] = [];
+  for (const item of items) {
+    const url = item.link;
+    if (!url || processedUrls.has(url)) continue;
+
+    // The feed always carries a real <pubDate>; an item without a parseable
+    // one is suspect — skip rather than stamp it "today" and let a stale
+    // article slip past the freshness window.
+    const raw = item.pubDate;
+    const published = raw ? new Date(raw) : null;
+    if (!published || Number.isNaN(published.getTime())) {
+      console.warn(`[ESG News] No parseable pubDate, skipping: ${url}`);
+      continue;
     }
+    if (published.getTime() < cutoffMs) continue;
+
+    const title = stripHtml(item.title ?? '');
+    if (!title || isDuplicateOfCarbonPulse(title, cpTitles)) continue;
+
+    // Defense-in-depth: feed HTML still carries share strips, related-article
+    // blocks and the editorial-team bio — strip it through the same barrier
+    // every scraper uses (cf. content.helpers).
+    const html = item['content:encoded'] ?? item.description ?? '';
+    const fullContent = sanitizeArticleText(stripHtml(html));
+    if (!fullContent) {
+      console.warn(`[ESG News] No article body after sanitization, skipping: ${url}`);
+      continue;
+    }
+
+    articles.push({
+      url,
+      title,
+      date: published.toISOString().slice(0, 10),
+      author: stripHtml(item['dc:creator'] ?? '') || 'ESG News',
+      excerpt: stripHtml(item.description ?? '') || title,
+      fullContent,
+    });
+    if (articles.length >= MAX_CANDIDATES) break;
   }
   return articles;
 }
 
+/**
+ * Scrape ESG News for the daily digest. Discovers articles from the publisher
+ * RSS feed, then asks the shared curator to pick the most relevant ones and
+ * tag each with a theme. Any failure degrades to an empty list — the caller
+ * (orchestrator) logs it and continues with the other sources.
+ */
 export async function scrapeEsgNews(
-  themes: readonly ThemeConfig[],
   processedUrls: ReadonlySet<string>,
   cpTitles: readonly string[],
-  firecrawlApiKey: string,
+  anthropicApiKey: string,
 ): Promise<RawArticle[]> {
-  if (!firecrawlApiKey) {
-    throw new Error('FIRECRAWL_API_KEY not configured — ESG News scraping skipped');
-  }
+  console.log('[ESG News] Fetching RSS feed...');
+  const feedArticles = await fetchFeedArticles(processedUrls, cpTitles);
+  console.log(`[ESG News] ${feedArticles.length} fresh candidate(s) from feed`);
+  if (feedArticles.length === 0) return [];
 
-  const allArticles: RawArticle[] = [];
-  // Carry URLs scraped under earlier themes forward, so an article matching
-  // multiple themes isn't re-discovered, re-scraped (wasting a credit) and
-  // returned twice.
-  const seenUrls = new Set(processedUrls);
-  for (const theme of themes) {
-    console.log(`[ESG News] Discovering: ${theme.name}`);
-    try {
-      const articles = await discoverAndScrape(theme, seenUrls, cpTitles, firecrawlApiKey);
-      allArticles.push(...articles);
-      for (const article of articles) seenUrls.add(article.url);
-      console.log(`[ESG News] Found ${articles.length} articles for ${theme.name}`);
-    } catch (error: unknown) {
-      // A 402/429 from the listing scrape itself (not the per-article scrape)
-      // propagates here; treat as quota exhaustion so the remaining themes
-      // don't hammer the exhausted API. Parity with `scrapeTrellis`.
-      if (isQuotaError(error)) {
-        const status = (error as FirecrawlError).status;
-        console.error(`[ESG News] Firecrawl ${status} during theme discovery — aborting remaining themes.`);
-        break;
-      }
-      const message = error instanceof Error ? error.message : 'unknown';
-      console.error(`[ESG News] Discovery failed for "${theme.name}": ${message}`);
-    }
+  const candidates: ArticleCandidate[] = feedArticles.map((article) => ({
+    url: article.url,
+    title: article.title,
+    date: article.date,
+    excerpt: article.excerpt,
+  }));
+  const picks = await curateArticles(
+    candidates,
+    THEMES.map((theme) => theme.name),
+    anthropicApiKey,
+    { maxPicks: MAX_PICKS, label: 'ESG News Curator' },
+  );
+
+  const articleByUrl = new Map(feedArticles.map((article) => [article.url, article]));
+  const result: RawArticle[] = [];
+  for (const pick of picks) {
+    const article = articleByUrl.get(pick.url);
+    if (!article) continue;
+    result.push({
+      source: 'esgnews',
+      url: article.url,
+      title: article.title,
+      date: article.date,
+      author: article.author,
+      mainTheme: pick.mainTheme,
+      categories: '',
+      location: '',
+      fullContent: article.fullContent,
+    });
   }
-  return allArticles;
+  console.log(`[ESG News] ${result.length} article(s) selected`);
+  return result;
 }

--- a/apps/news-digest/pipeline/src/scraper/trellis.ts
+++ b/apps/news-digest/pipeline/src/scraper/trellis.ts
@@ -1,5 +1,5 @@
 import { THEMES } from '../config.constants.js';
-import { curateTrellisArticles, type TrellisCandidate } from '../ai/trellis-curator.js';
+import { curateArticles, type ArticleCandidate } from '../ai/article-curator.js';
 import { sanitizeArticleText } from '../helpers/content.helpers.js';
 import { parseDate } from '../helpers/date.helpers.js';
 import {
@@ -148,7 +148,7 @@ async function discoverThemeAndScrape(
 async function collectCandidates(
   excludeUrls: ReadonlySet<string>,
   apiKey: string,
-): Promise<TrellisCandidate[]> {
+): Promise<ArticleCandidate[]> {
   // Single broad-pool scrape per run; shared across all themes via the curator.
   const listing = await firecrawlScrape(CURATION_LISTING_URL, apiKey);
   // Over-request: host/exclude/dedup filtering would otherwise shrink the pool
@@ -230,7 +230,9 @@ export async function scrapeTrellis(
     } else {
       const candidateByUrl = new Map(candidates.map((candidate) => [candidate.url, candidate]));
       const allThemeNames = THEMES.map((theme) => theme.name);
-      const picks = await curateTrellisArticles(candidates, allThemeNames, anthropicApiKey);
+      const picks = await curateArticles(candidates, allThemeNames, anthropicApiKey, {
+        label: 'Trellis Curator',
+      });
       const scrapedPickUrls = new Set<string>();
       for (const pick of picks) {
         const candidate = candidateByUrl.get(pick.url);


### PR DESCRIPTION
### Summary

The daily news digest collapsed to a single article on 2026-05-21. Root cause: ESG News discovery was broken. This PR switches ESG News discovery from the publisher's `?s=` search to its RSS feed, restoring ESG as a working digest source.

### Details

**The bug.** ESG News discovery scraped `esgnews.com/?s=<theme terms>`, assuming WordPress `?s=` returns date-ordered search results. Validated on 2026-05-21 that this assumption is false: `esgnews.com` ignores the query term **and** `orderby` entirely — `?s=methane`, `?s=methane+superpollutant`, `?s=...&orderby=date` and `/category/carbon-markets/` all return a byte-identical fixed post grid. ESG discovery surfaced ~0 fresh articles for every theme, and with Carbon Pulse disabled, the digest fell back to a single Trellis curator pick.

**The fix.** ESG News discovery now reads `esgnews.com/feed/` — the publisher RSS feed: date-desc ordered, real `<pubDate>`, and `<content:encoded>` carries the full article body. Consequences:

- ESG News no longer uses Firecrawl at all — discovery is a single feed fetch and the body comes straight from the feed (same model as the Substack scraper). Removes a per-listing + per-article Firecrawl credit cost.
- Discovery is global (one fetch) instead of a per-theme loop. The Trellis curator is generalized into a shared `ai/article-curator.ts` (`curateArticles`, with `maxPicks` / `label` options); the ESG candidate pool runs through it for theme assignment and selection (3 picks). Trellis behavior is unchanged (still 2 picks).
- The defense-in-depth `sanitizeArticleText` barrier and Carbon Pulse title de-duplication are preserved.

**Files**

- `scraper/esg-news.ts` — rewritten: RSS feed discovery, freshness + dedup filters, curator-driven selection.
- `ai/article-curator.ts` — new, generalized from `ai/trellis-curator.ts` (removed).
- `scraper/trellis.ts`, `orchestrator.ts` — wired to the renamed curator / new `scrapeEsgNews` signature.
- `helpers/firecrawl.helpers.ts` — comment updated (now Trellis-only).

**Testing**

```bash
cd apps/news-digest/pipeline && npx vitest run
```

196 tests pass (18 files), including 12 new ESG News scraper tests and 15 article-curator tests. `npx nx build news-digest-pipeline` succeeds.

### Deployment Notes

This fix only affects the scheduled run after the `news-digest-pipeline` Docker image is rebuilt and pushed to ECR. Merging to `main` alone does not change the live pipeline.

### Related links

- Memory note: ESG `?s=` search is non-functional — discovery must use `esgnews.com/feed/`.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rewrites ESG News ingestion from Firecrawl-based search scraping to RSS parsing and curator-based selection, changing the main article source behavior. Also generalizes/renames the curator used by Trellis, which could affect pick validation and logging across sources.
> 
> **Overview**
> **ESG News discovery is rewritten to use the publisher RSS feed** (`/feed/`) instead of scraping `?s=` search pages, eliminating Firecrawl usage for ESG News and pulling article body/metadata directly from feed XML with freshness, dedup, and sanitization filters.
> 
> Introduces a **shared `curateArticles` Claude-based curator** (replacing the Trellis-specific curator) with `maxPicks` and `label` options, adds stricter pick validation (dedup repeated URLs), and wires ESG News to request up to **3 curated picks** while Trellis keeps the default cap.
> 
> Updates the pipeline orchestrator and Trellis scraper/tests to the new curator and the new `scrapeEsgNews` signature, and refreshes tests to cover RSS parsing, candidate capping, and curator options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535083555ea10540a0519f752528d4214a7a7520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->